### PR TITLE
fix: S3 Buckets in example IAM template

### DIFF
--- a/src/foremast/iam/construct_policy.py
+++ b/src/foremast/iam/construct_policy.py
@@ -61,7 +61,9 @@ def construct_policy(app='coreforrest', env='dev', group='forrest', region='us-e
 
     statements = []
     for service, value in services.items():
-        if isinstance(value, (bool, str)):
+        if value is True:
+            items = []
+        elif isinstance(value, str):
             items = [value]
         else:
             items = value

--- a/src/foremast/templates/infrastructure/iam/s3.json.j2
+++ b/src/foremast/templates/infrastructure/iam/s3.json.j2
@@ -6,11 +6,9 @@
             ],
             "Resource": [
                 {% for bucket in items -%}
-                  "arn:aws:s3:::{{ bucket }}"
-                  {%- if not loop.last -%}
-                    ,
-                  {%- endif %}
+                  "arn:aws:s3:::{{ bucket }}",
                 {% endfor -%}
+                "arn:aws:s3:::default_bucket_name"
             ]
         },
         {
@@ -22,10 +20,8 @@
             ],
             "Resource": [
                 {% for bucket in items -%}
-                  "arn:aws:s3:::{{ bucket }}/*"
-                  {%- if not loop.last -%}
-                    ,
-                  {%- endif %}
+                  "arn:aws:s3:::{{ bucket }}/*",
                 {% endfor -%}
+                "arn:aws:s3:::default_bucket_name/*"
             ]
         }

--- a/tests/iam/test_iam_construct.py
+++ b/tests/iam/test_iam_construct.py
@@ -86,7 +86,6 @@ def test_construct_s3(requests_get):
     assert len(allow_edit_policy['Resource']) == 1
 
 
-
 @mock.patch('foremast.utils.credentials.API_URL', 'http://test.com')
 @mock.patch('foremast.utils.credentials.requests.get')
 def test_construct_s3_buckets(requests_get):
@@ -104,6 +103,6 @@ def test_construct_s3_buckets(requests_get):
 
     allow_list_policy, allow_edit_policy = policy['Statement']
 
-    assert len(allow_list_policy['Resource']) == 2
+    assert len(allow_list_policy['Resource']) == 3
 
-    assert len(allow_edit_policy['Resource']) == 2
+    assert len(allow_edit_policy['Resource']) == 3


### PR DESCRIPTION
Include multiple S3 Buckets support in example template. When Service is `True`, behaviour will change to passing an empty list.
