### PR TITLE
added slash removal for api_gateway resource creation

### DIFF
--- a/src/foremast/awslambda/api_gateway_event/api_gateway_event.py
+++ b/src/foremast/awslambda/api_gateway_event/api_gateway_event.py
@@ -194,10 +194,11 @@ class APIGateway:
         Args:
             parent_id (str): The resource ID of the parent resource in API Gateway
         """
+        resource_name = self.trigger_settings.get('resource', '')
+        resource_name.replace("/", "")
         created_resource = self.client.create_resource(restApiId=self.api_id,
                                                        parentId=parent_id,
-                                                       pathPart=self.trigger_settings.get('resource',
-                                                                      '/'))
+                                                       pathPart=resource_name)
         resource_id = created_resource['id']
         self.log.info("Successfully created resource")
         return resource_id


### PR DESCRIPTION
There was a bug with slashes in resources creation for API gateway. These slashes are necessary for finding the resource though. I thought it would be best to just strip slashes on creation.
