### PR TITLE
plugin: Clean up inheritance

### DIFF
--- a/src/foremast/app/aws.py
+++ b/src/foremast/app/aws.py
@@ -1,8 +1,5 @@
 """AWS Spinnaker Application."""
-from pprint import pformat
-
 from foremast.app import base
-from foremast.utils import wait_for_task
 
 
 class SpinnakerApp(base.BaseApp):
@@ -11,20 +8,9 @@ class SpinnakerApp(base.BaseApp):
     provider = 'aws'
 
     def create(self):
-        """Send a POST to spinnaker to create a new application with class variables.
-
-        Raises:
-            AssertionError: Application creation failed.
-
-        """
-        self.appinfo['accounts'] = self.get_accounts()
-        self.log.debug('App info:\n%s', pformat(self.appinfo))
-
-        jsondata = self.render_application_template()
-        wait_for_task(jsondata)
-
-        self.log.info("Successfully created %s application", self.appname)
-        return
+        """Prepare AWS specific data before creation."""
+        result = super().create()
+        return result
 
     def delete(self):
         """Delete AWS Spinnaker Application."""

--- a/src/foremast/app/aws.py
+++ b/src/foremast/app/aws.py
@@ -18,8 +18,8 @@ class SpinnakerApp(base.BaseApp):
 
         """
         self.appinfo['accounts'] = self.get_accounts()
-        self.log.debug('Pipeline Config\n%s', pformat(self.pipeline_config))
         self.log.debug('App info:\n%s', pformat(self.appinfo))
+
         jsondata = self.render_application_template()
         wait_for_task(jsondata)
 

--- a/src/foremast/app/base.py
+++ b/src/foremast/app/base.py
@@ -45,15 +45,18 @@ class BaseApp(BasePlugin):
         Raises:
             AssertionError: Application creation failed.
 
+        Returns:
+            str: Task status.
+
         """
         self.appinfo['accounts'] = self.get_accounts()
         self.log.debug('App info:\n%s', pformat(self.appinfo))
 
         jsondata = self.render_application_template()
-        wait_for_task(jsondata)
+        task_status = wait_for_task(jsondata)
 
         self.log.info("Successfully created %s application in %s", self.appname, self.provider)
-        return
+        return task_status
 
     def render_application_template(self):
         """Render application from configs.

--- a/src/foremast/app/base.py
+++ b/src/foremast/app/base.py
@@ -45,6 +45,9 @@ class BaseApp(BasePlugin):
             dict: Rendered application template.
         """
         self.pipeline_config['instance_links'] = self.retrieve_instance_links()
+
+        self.log.debug('Pipeline Config\n%s', pformat(self.pipeline_config))
+
         jsondata = get_template(
             template_file='infrastructure/app_data.json.j2', appinfo=self.appinfo, pipeline_config=self.pipeline_config)
         return jsondata

--- a/src/foremast/app/base.py
+++ b/src/foremast/app/base.py
@@ -52,7 +52,7 @@ class BaseApp(BasePlugin):
         jsondata = self.render_application_template()
         wait_for_task(jsondata)
 
-        self.log.info("Successfully created %s application", self.appname)
+        self.log.info("Successfully created %s application in %s", self.appname, self.provider)
         return
 
     def render_application_template(self):
@@ -82,11 +82,8 @@ class BaseApp(BasePlugin):
 
         return instance_links
 
-    def get_accounts(self, provider='aws'):
+    def get_accounts(self):
         """Get Accounts added to Spinnaker.
-
-        Args:
-            provider (str): What provider to find accounts for.
 
         Returns:
             list: list of dicts of Spinnaker credentials matching _provider_.
@@ -103,10 +100,10 @@ class BaseApp(BasePlugin):
 
         filtered_accounts = []
         for account in all_accounts:
-            if account['type'] == provider:
+            if account['type'] == self.provider:
                 filtered_accounts.append(account)
 
         if not filtered_accounts:
-            raise ForemastError('No Accounts matching {0}.'.format(provider))
+            raise ForemastError('No Accounts matching {0}.'.format(self.provider))
 
         return filtered_accounts

--- a/src/foremast/app/base.py
+++ b/src/foremast/app/base.py
@@ -40,7 +40,7 @@ class BaseApp(BasePlugin):
         self.pipeline_config = pipeline_config
 
     def create(self):
-        """Send a POST to spinnaker to create a new application with class variables.
+        """Create a Spinnaker Application.
 
         Raises:
             AssertionError: Application creation failed.


### PR DESCRIPTION
Move common code to the `BaseApp` and leave room in the custom Provider Plugins to do custom things.