### PR TITLE
refactor: Support overriding EC2 Pipeline Types

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -141,6 +141,12 @@ security group name, it will self-reference to its own application name.
     | *Required*: No
     | *Example*: ``{ "bastion" : [ { "start_port": "22", "end_port": "22", "protocol": "tcp" } ] }``
 
+``ec2_pipeline_types``
+**********************
+
+.. autodata:: foremast.consts.EC2_PIPELINE_TYPES
+   :noindex:
+
 ``gate_client_cert``
 ********************
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -201,6 +201,19 @@ AMI_JSON_URL = validate_key_values(CONFIG, 'base', 'ami_json_url')
 DEFAULT_SECURITYGROUP_RULES = _generate_security_groups('default_securitygroup_rules')
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')
+
+EC2_PIPELINE_TYPES = tuple(validate_key_values(CONFIG, 'base', 'ec2_pipeline_types', default='ec2,rolling').split(','))
+"""Comma separated list of Pipeline Types to treat as EC2 deployments.
+
+This is useful when defining custom Pipeline Types. When Pipeline Type matches,
+EC2 specific data is used in deployment, such as Auto Scaling Groups and
+Availability Zones.
+
+    | *Default*: ``ec2,rolling``
+    | *Required*: No
+    | *Example*: ``ec2,infrastructure,propeller``
+"""
+
 SECURITYGROUP_REPLACEMENTS = _convert_string_to_native(
     validate_key_values(
         CONFIG,

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -20,7 +20,7 @@ import json
 import logging
 from pprint import pformat
 
-from ..consts import ASG_WHITELIST, DEFAULT_EC2_SECURITYGROUPS
+from ..consts import ASG_WHITELIST, DEFAULT_EC2_SECURITYGROUPS, EC2_PIPELINE_TYPES
 from ..utils import generate_encoded_user_data, get_template, remove_duplicate_sg
 
 LOG = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ def construct_pipeline_block(env='',
     pipeline_type = pipeline_data['type']
     gen_app_name = generated.app_name()
 
-    if pipeline_type in ('ec2', 'rolling'):
+    if pipeline_type in EC2_PIPELINE_TYPES:
         data = ec2_pipeline_setup(
             appname=gen_app_name,
             settings=settings,

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -22,7 +22,7 @@ from pprint import pformat
 
 import requests
 
-from ..consts import API_URL, GATE_CA_BUNDLE, GATE_CLIENT_CERT
+from ..consts import API_URL, EC2_PIPELINE_TYPES, GATE_CA_BUNDLE, GATE_CLIENT_CERT
 from ..exceptions import SpinnakerPipelineCreationFailed
 from ..utils import ami_lookup, generate_packer_filename, get_details, get_properties, get_subnets, get_template
 from .clean_pipelines import clean_pipelines
@@ -220,7 +220,7 @@ class SpinnakerPipeline:
                     "pipeline_data": self.settings['pipeline'],
                 }
 
-                if self.settings['pipeline']['type'] in ('ec2', 'rolling'):
+                if self.settings['pipeline']['type'] in EC2_PIPELINE_TYPES:
                     if not subnets:
                         subnets = get_subnets()
                     try:

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -17,7 +17,8 @@
 from configparser import ConfigParser
 from unittest.mock import patch
 
-from foremast.consts import ALLOWED_TYPES, DEFAULT_SECURITYGROUP_RULES, _generate_security_groups, extract_formats
+from foremast.consts import (ALLOWED_TYPES, DEFAULT_SECURITYGROUP_RULES, EC2_PIPELINE_TYPES, _generate_security_groups,
+                             extract_formats)
 
 
 def test_consts_extract_formats():
@@ -61,3 +62,9 @@ def test_parse_security_group(values):
 def test_parse_security_group_dict(mock_keys):
     """Validate security groups are handled properly if dictionary is in dyanmic config"""
     assert {'': ['g3']} == _generate_security_groups('default_elb_securitygroups')
+
+
+def test_parse_ec2_pipeline_types():
+    """Validate EC2 Pipeline Types."""
+    assert EC2_PIPELINE_TYPES == ('ec2', 'rolling')
+    assert isinstance(EC2_PIPELINE_TYPES, tuple)


### PR DESCRIPTION
Need a way to inject custom Pipeline Types that are deployed with EC2.