### PR TITLE
fix: Use dict configs

### DIFF
--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -87,8 +87,10 @@ def extract_formats(config_handle):
     return formats
 
 
-def load_dynamic_config(configurations, config_dir=getcwd()):
+def load_dynamic_config(config_dir=getcwd()):
     """Load and parse dynamic config"""
+    dynamic_configurations = {}
+
     # Create full path of config
     config_file = '{path}/config.py'.format(path=config_dir)
 
@@ -97,14 +99,12 @@ def load_dynamic_config(configurations, config_dir=getcwd()):
     try:
         config_module = __import__('config')
 
-        for key, value in config_module.CONFIG.items():
-            LOG.debug('Importing %s with key %s', key, value)
-            # Update configparser object
-            configurations.update({key: value})
+        dynamic_configurations = config_module.CONFIG
     except ImportError:
         # Provide a default if config not found
         LOG.error('ImportError: Unable to load dynamic config. Check config.py file imports!')
-        configurations = {}
+
+    return dynamic_configurations
 
 
 def find_config():
@@ -130,7 +130,7 @@ def find_config():
         LOG.info('Loading static configuration file.')
     elif exists(dynamic_config_file):
         LOG.info('Loading dynamic configuration file.')
-        load_dynamic_config(configurations)
+        configurations = load_dynamic_config()
     else:
         config_locations.append(dynamic_config_file)
         LOG.warning('No configuration found in the following locations:\n%s', '\n'.join(config_locations))

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -29,7 +29,7 @@ import ast
 import json
 import logging
 import sys
-from configparser import ConfigParser, DuplicateSectionError
+from configparser import ConfigParser
 from os import getcwd, path
 from os.path import exists, expanduser, expandvars
 
@@ -56,18 +56,13 @@ def validate_key_values(config_handle, section, key, default=None):
     Returns:
         object: ``str`` when *key* exists, otherwise *default* object.
     """
-    try:
-        config_handle.add_section(section)
+    if section not in config_handle:
         LOG.info('Section missing from configurations: [%s]', section)
-    except DuplicateSectionError:
-        pass
-
-    section_handle = config_handle[section]
 
     try:
-        value = section_handle[key]
+        value = config_handle[section][key]
     except KeyError:
-        LOG.warning('[%s] missing key "%s", using %r.', section_handle.name, key, default)
+        LOG.warning('[%s] missing key "%s", using %r.', section, key, default)
         value = default
 
     return value

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -79,11 +79,8 @@ def extract_formats(config_handle):
         dict: of formats in {$format_type: $format_pattern}.
         See (gogoutils.Formats) for available options.
     """
-    formats = {}
-
-    if config_handle.has_section('formats'):
-        formats = dict(config_handle['formats'])
-
+    configurations = dict(config_handle)
+    formats = dict(configurations.get('formats', {}))
     return formats
 
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -106,13 +106,13 @@ def load_dynamic_config(config_dir=getcwd()):
 
 
 def find_config():
-    """Look for **foremast.cfg** in config_locations.
+    """Look for **foremast.cfg** in config_locations or ``./config.py``.
 
     Raises:
         SystemExit: No configuration file found.
 
     Returns:
-        dict: found configuration file
+        dict: Found dynamic or static configuration.
 
     """
     config_locations = [

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -71,13 +71,14 @@ def validate_key_values(config_handle, section, key, default=None):
 def extract_formats(config_handle):
     """Get application formats.
 
+    See :class:`gogoutils.Formats` for available options.
+
     Args:
         config_handle (configparser.ConfigParser): Instance of configurations.
 
     Returns:
-        object: ``str`` when *key* exists, otherwise *default* object.
-        dict: of formats in {$format_type: $format_pattern}.
-        See (gogoutils.Formats) for available options.
+        dict: Formats in ``{$format_type: $format_pattern}``.
+
     """
     configurations = dict(config_handle)
     formats = dict(configurations.get('formats', {}))

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -114,7 +114,8 @@ def find_config():
         SystemExit: No configuration file found.
 
     Returns:
-        ConfigParser: found configuration file
+        dict: found configuration file
+
     """
     config_locations = [
         '/etc/foremast/foremast.cfg',
@@ -136,7 +137,7 @@ def find_config():
         LOG.warning('No configuration found in the following locations:\n%s', '\n'.join(config_locations))
         LOG.warning('Using defaults...')
 
-    return configurations
+    return dict(configurations)
 
 
 def _remove_empty_entries(entries):


### PR DESCRIPTION
Need to start using the configurations in the `dict` form. The way `configparser.ConfigParser` works, it squashes all configuration values into `str` and negates some of the benefits of using Dynamic Configurations with `config.py`.

In particular, I'm concerned with the Application Format configurations in `config.py`. Because I want to use some bizarre string formatting, I need to override the `str.format()` behaviour using a Subclass.

```python
# config.py

class AppName(str):
    """Custom Application name manipulation."""

    def format(self, *args, **kwargs):
        """Override default formatting."""
        repo = kwargs['repo']
        first, *rest = repo.split('-')
        camel = [word.capitalize() for word in rest]

        app_name = ''.join([first, *camel])

        return super().format(*args, app_name=app_name, **kwargs)

CONFIG = {
    'formats': {
        'app': AppName('{app_name}'),
    },
}
```

But because `configparser.ConfigParser` squashes everything (essentially running everything through `str()`), I end up with:

```python
CONFIG = {
    'formats': {
        'app': '{app_name}',
    },
}
```

In an effort to deprecate INI style configurations, we need to remove `configparser.ConfigParser` specific interactions. This also simplifies some parts and avoids side effects in Functions.