### PR TITLE
feat: Deploy with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,11 @@ notifications:
     on_success: never
     on_failure: always
     on_start: never
+deploy:
+  provider: pypi
+  user: foremast-deployer
+  password:
+    secure: UfsQ12Ox1wB5nWSIC26zJle2a3TM+agVkHjCV9y1z7DUMhvQgSx05M9cWL8ZsAQBGhjeF8HPwgxTxg9Kr3ayR4m/BuQIztsahiMhg1DK3taOEla+WcT3/+EVPgGwn5w91Vntn3S4j4f7Ym8WqDdI/o0m/Bn6Lt6Cx/dPXTskhNXp/SaHW/Xd6r32objsD4UqKRVOb/WGFtDfDypZc/Uz1aXkaFCR8CFzebxWh3eKWhdgJE5x13bNEPDUz3X1Al872SSF/3vQ8H2rtZxtODROPjaxNrrTKdEh9f4/q5NHWxyEuyViBk7YHdzuZxinHScxFv3roBy29jl+qSzZgdTNYBKeMp7YJqiOshgCUFLPQHTHZyUpb3E/ELAC2ULJOwD+Wz5Fo84gVFwUNu5I7qQiWeQa4+9y0qjpGFFGLNf5GspUpBY8dzkF9ZjPadpmWfU2IaMIYQ7W3fojz8ok8jZ2CCrXiZEm400WRewI7SIqLmBZZAIZ08yJSyTTJgH32YfeVCBKGkiRVd1U4H4xTnxaghrRktC3M3NZgbxpUosiQY6k2k85I6J0jv5Q12k+mi5sU6G3z36ZPeu4+gGNqCERbwVK2aITQDh5HC/tw++FLyxTwZ0l5xahWHzxgwobplbk18bcAUdoPmgDT0w9x0zeRwfdY5S9RwfAakYPDMB02dE=
+  distributions: bdist_wheel
+  on:
+    condition: $TOXENV = lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,18 @@ notifications:
     on_failure: always
     on_start: never
 deploy:
-  provider: pypi
+- provider: pypi
   user: foremast-deployer
   password:
     secure: UfsQ12Ox1wB5nWSIC26zJle2a3TM+agVkHjCV9y1z7DUMhvQgSx05M9cWL8ZsAQBGhjeF8HPwgxTxg9Kr3ayR4m/BuQIztsahiMhg1DK3taOEla+WcT3/+EVPgGwn5w91Vntn3S4j4f7Ym8WqDdI/o0m/Bn6Lt6Cx/dPXTskhNXp/SaHW/Xd6r32objsD4UqKRVOb/WGFtDfDypZc/Uz1aXkaFCR8CFzebxWh3eKWhdgJE5x13bNEPDUz3X1Al872SSF/3vQ8H2rtZxtODROPjaxNrrTKdEh9f4/q5NHWxyEuyViBk7YHdzuZxinHScxFv3roBy29jl+qSzZgdTNYBKeMp7YJqiOshgCUFLPQHTHZyUpb3E/ELAC2ULJOwD+Wz5Fo84gVFwUNu5I7qQiWeQa4+9y0qjpGFFGLNf5GspUpBY8dzkF9ZjPadpmWfU2IaMIYQ7W3fojz8ok8jZ2CCrXiZEm400WRewI7SIqLmBZZAIZ08yJSyTTJgH32YfeVCBKGkiRVd1U4H4xTnxaghrRktC3M3NZgbxpUosiQY6k2k85I6J0jv5Q12k+mi5sU6G3z36ZPeu4+gGNqCERbwVK2aITQDh5HC/tw++FLyxTwZ0l5xahWHzxgwobplbk18bcAUdoPmgDT0w9x0zeRwfdY5S9RwfAakYPDMB02dE=
   distributions: bdist_wheel
   on:
     condition: $TOXENV = lint
+- provider: pypi
+  user: foremast-deployer
+  password:
+    secure: UfsQ12Ox1wB5nWSIC26zJle2a3TM+agVkHjCV9y1z7DUMhvQgSx05M9cWL8ZsAQBGhjeF8HPwgxTxg9Kr3ayR4m/BuQIztsahiMhg1DK3taOEla+WcT3/+EVPgGwn5w91Vntn3S4j4f7Ym8WqDdI/o0m/Bn6Lt6Cx/dPXTskhNXp/SaHW/Xd6r32objsD4UqKRVOb/WGFtDfDypZc/Uz1aXkaFCR8CFzebxWh3eKWhdgJE5x13bNEPDUz3X1Al872SSF/3vQ8H2rtZxtODROPjaxNrrTKdEh9f4/q5NHWxyEuyViBk7YHdzuZxinHScxFv3roBy29jl+qSzZgdTNYBKeMp7YJqiOshgCUFLPQHTHZyUpb3E/ELAC2ULJOwD+Wz5Fo84gVFwUNu5I7qQiWeQa4+9y0qjpGFFGLNf5GspUpBY8dzkF9ZjPadpmWfU2IaMIYQ7W3fojz8ok8jZ2CCrXiZEm400WRewI7SIqLmBZZAIZ08yJSyTTJgH32YfeVCBKGkiRVd1U4H4xTnxaghrRktC3M3NZgbxpUosiQY6k2k85I6J0jv5Q12k+mi5sU6G3z36ZPeu4+gGNqCERbwVK2aITQDh5HC/tw++FLyxTwZ0l5xahWHzxgwobplbk18bcAUdoPmgDT0w9x0zeRwfdY5S9RwfAakYPDMB02dE=
+  distributions: bdist_wheel
+  on:
+    condition: $TOXENV = lint
+    tags: true


### PR DESCRIPTION
One `deploy` block will deploy Commits to the `master` Branch. The other block will deploy Tags. I can't figure out a way to combine these into one block due to the way Travis `deploy` works where specifying `tags` ignores `branch` and specifying `branch` ignores `tags`.

There is a small race condition if Tags are pushed faster than Travis can start building the Branch Commit. This results in both Branch and Tag builds trying to deploy the same Tagged version and one will show as false failure.

Example false failure:
* `master` Commit build created: https://travis-ci.org/e4r7hbug/foremast/builds/389587423
    ```
    Uploading distributions to https://test.pypi.org/legacy/
    Uploading foremast-3.46.3-py2.py3-none-any.whl
    100% 206k/206k [00:01<00:00, 109kB/s]
    ```
* Tag build: https://travis-ci.org/e4r7hbug/foremast/builds/389587428
    ```
    Uploading distributions to https://test.pypi.org/legacy/
    Uploading foremast-3.46.3-py2.py3-none-any.whl
    100% 206k/206k [00:00<00:00, 331kB/s]
    HTTPError: 400 Client Error: File already exists. See https://test.pypi.org/help/#file-name-reuse for url: https://test.pypi.org/legacy/
    ```

See also: #300