### PR TITLE
docs: Fixed wrong key in lambda_environment example for application json

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -85,7 +85,7 @@ Environment variables which are passed to the lambda function.
 .. code-block:: json
 
    {
-       "environment": {
+       "lambda_environment": {
            "Variables": {
                "VAR1": "val1",
                "VAR2": "val2",


### PR DESCRIPTION
Just a quick small docs fix. The key used in the example is "environment" but should be "lambda_environment".