### PR TITLE
Support to run pipelines using a default `Run As User`

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -107,6 +107,15 @@ relative to where you where you are running the Foremast commands. See
 
     | *Required*: No
 
+``default_run_as_user``
+***********************
+
+Default user to run pipelines as. This is needed for leveraging service accounts in Fiat.
+
+    | *Type*: str
+    | *Default*: ``''``
+    | *Required*: No
+
 ``default_ec2_securitygroups``
 ******************************
 

--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -113,7 +113,7 @@ relative to where you where you are running the Foremast commands. See
 Default user to run pipelines as. This is needed for leveraging service accounts in Fiat.
 
     | *Type*: str
-    | *Default*: ``''``
+    | *Default*: ``null``
     | *Required*: No
 
 ``default_ec2_securitygroups``

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -198,7 +198,7 @@ ALLOWED_TYPES = set(
     validate_key_values(CONFIG, 'base', 'types', default='ec2,lambda,s3,datapipeline,rolling').split(','))
 TEMPLATES_PATH = validate_key_values(CONFIG, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(CONFIG, 'base', 'ami_json_url')
-DEFAULT_RUN_AS_USER = validate_key_values(CONFIG, 'base', 'default_run_as_user', default='')
+DEFAULT_RUN_AS_USER = validate_key_values(CONFIG, 'base', 'default_run_as_user', default=None)
 DEFAULT_SECURITYGROUP_RULES = _generate_security_groups('default_securitygroup_rules')
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -198,6 +198,7 @@ ALLOWED_TYPES = set(
     validate_key_values(CONFIG, 'base', 'types', default='ec2,lambda,s3,datapipeline,rolling').split(','))
 TEMPLATES_PATH = validate_key_values(CONFIG, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(CONFIG, 'base', 'ami_json_url')
+DEFAULT_RUN_AS_USER = validate_key_values(CONFIG, 'base', 'default_run_as_user', default='')
 DEFAULT_SECURITYGROUP_RULES = _generate_security_groups('default_securitygroup_rules')
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -22,7 +22,7 @@ from pprint import pformat
 
 import requests
 
-from ..consts import API_URL, EC2_PIPELINE_TYPES, GATE_CA_BUNDLE, GATE_CLIENT_CERT
+from ..consts import API_URL, EC2_PIPELINE_TYPES, GATE_CA_BUNDLE, GATE_CLIENT_CERT, DEFAULT_RUN_AS_USER
 from ..exceptions import SpinnakerPipelineCreationFailed
 from ..utils import ami_lookup, generate_packer_filename, get_details, get_properties, get_subnets, get_template
 from .clean_pipelines import clean_pipelines
@@ -124,6 +124,7 @@ class SpinnakerPipeline:
                 'environment': 'packaging',
                 'region': region,
                 'triggerjob': self.trigger_job,
+                'run_as_user': DEFAULT_RUN_AS_USER,
                 'email': email,
                 'slack': slack,
                 'root_volume_size': root_volume_size,

--- a/src/foremast/pipeline/create_pipeline_datapipeline.py
+++ b/src/foremast/pipeline/create_pipeline_datapipeline.py
@@ -19,6 +19,7 @@ import json
 from pprint import pformat
 
 from ..utils import get_template
+from ..consts import DEFAULT_RUN_AS_USER
 from .clean_pipelines import clean_pipelines
 from .construct_pipeline_block_datapipeline import construct_datapipeline
 from .create_pipeline import SpinnakerPipeline
@@ -61,6 +62,7 @@ class SpinnakerPipelineDataPipeline(SpinnakerPipeline):
                 'environment': 'packaging',
                 'region': region,
                 'triggerjob': self.trigger_job,
+                'run_as_user': DEFAULT_RUN_AS_USER,
                 'email': email,
                 'slack': slack,
                 'pipeline': self.settings['pipeline']

--- a/src/foremast/pipeline/create_pipeline_lambda.py
+++ b/src/foremast/pipeline/create_pipeline_lambda.py
@@ -19,6 +19,7 @@ import json
 from pprint import pformat
 
 from ..utils import get_subnets, get_template
+from ..consts import DEFAULT_RUN_AS_USER
 from .clean_pipelines import clean_pipelines
 from .construct_pipeline_block_lambda import construct_pipeline_block_lambda
 from .create_pipeline import SpinnakerPipeline
@@ -64,6 +65,7 @@ class SpinnakerPipelineLambda(SpinnakerPipeline):
                 'environment': 'packaging',
                 'region': region,
                 'triggerjob': self.trigger_job,
+                'run_as_user': DEFAULT_RUN_AS_USER,
                 'email': email,
                 'slack': slack,
                 'pipeline': self.settings['pipeline']

--- a/src/foremast/pipeline/create_pipeline_s3.py
+++ b/src/foremast/pipeline/create_pipeline_s3.py
@@ -19,6 +19,7 @@ import json
 from pprint import pformat
 
 from ..utils import get_template
+from ..consts import DEFAULT_RUN_AS_USER
 from .clean_pipelines import clean_pipelines
 from .construct_pipeline_block_s3 import construct_pipeline_block_s3
 from .create_pipeline import SpinnakerPipeline
@@ -64,6 +65,7 @@ class SpinnakerPipelineS3(SpinnakerPipeline):
                 'environment': 'packaging',
                 'region': region,
                 'triggerjob': self.trigger_job,
+                'run_as_user': DEFAULT_RUN_AS_USER,
                 'email': email,
                 'slack': slack,
                 'pipeline': self.settings['pipeline']

--- a/src/foremast/templates/configs/config.py.example
+++ b/src/foremast/templates/configs/config.py.example
@@ -9,6 +9,7 @@ CONFIG = {
         'git_url': 'https://git.example.com',
         'gate_api_url': 'http://gate-api.example.com:8084',
         'templates_path': '../../foremast-templates',
+        'default_run_as_user': 'trigger_runner',
         'default_securitygroup_rules': {
             'bastion': [{'start_port': '22', 'end_port': '22', 'protocol': 'tcp'}],
             'serviceapp': [{'start_port': '8080', 'end_port': '8080', 'protocol': 'tcp' }],

--- a/src/foremast/templates/configs/foremast.cfg.example
+++ b/src/foremast/templates/configs/foremast.cfg.example
@@ -7,6 +7,7 @@ ami_json_url = http://s3.bucketname.com/ami_lookup.json
 git_url = https://git.example.com
 gate_api_url = http://gate-api.example.com:8084
 templates_path = ../../foremast-templates
+default_run_as_user = trigger_runner
 default_securitygroup_rules = { "bastion" : [ { "start_port": "22", "end_port": "22", "protocol": "tcp" } ],
                                 "serviceapp" : [ { "start_port": "8080", "end_port": "8080", "protocol": "tcp" } ] }
 

--- a/src/foremast/templates/configs/pipeline.json.j2
+++ b/src/foremast/templates/configs/pipeline.json.j2
@@ -23,10 +23,10 @@
     },
     "pipeline_files": [],
     "chaos_monkey": {
-      "enabled": false,
-      "mean_time": 5,
-      "minimum_time": 3,
-      "exceptions": []
+        "enabled": false,
+        "mean_time": 5,
+        "minimum_time": 3,
+        "exceptions": []
     },
     "instance_links": {},
     "permissions": {

--- a/src/foremast/templates/pipeline/trigger-jenkins.json.j2
+++ b/src/foremast/templates/pipeline/trigger-jenkins.json.j2
@@ -4,6 +4,6 @@
       "type": "jenkins",
       "master": "JenkinsCI",
       "job": "{{ data.app.triggerjob }}",
-      "runAsUser": "{{ data.app.run_as_user }}",
+      "runAsUser": {{ data.app.run_as_user|tojson }},
       "propertyFile": "jenkins_vars"
     }

--- a/src/foremast/templates/pipeline/trigger-jenkins.json.j2
+++ b/src/foremast/templates/pipeline/trigger-jenkins.json.j2
@@ -4,5 +4,6 @@
       "type": "jenkins",
       "master": "JenkinsCI",
       "job": "{{ data.app.triggerjob }}",
+      "runAsUser": "{{ data.app.run_as_user }}",
       "propertyFile": "jenkins_vars"
     }


### PR DESCRIPTION
- Needed for Fiat enabled applications to specify service account