### PR TITLE
Send `gogoutils.Generator` to templates

### DIFF
--- a/src/foremast/configs/outputs.py
+++ b/src/foremast/configs/outputs.py
@@ -86,7 +86,12 @@ def write_variables(app_configs=None, out_file='', git_short=''):
         if env != 'pipeline':
             instance_profile = generated.iam()['profile']
             rendered_configs = json.loads(
-                get_template('configs/configs.json.j2', env=env, app=generated.app_name(), profile=instance_profile))
+                get_template(
+                    'configs/configs.json.j2',
+                    env=env,
+                    app=generated.app_name(),
+                    profile=instance_profile,
+                    generated=generated))
             json_configs[env] = dict(DeepChainMap(configs, rendered_configs))
             region_list = configs.get('regions', rendered_configs['regions'])
             json_configs[env]['regions'] = region_list  # removes regions defined in templates but not configs.
@@ -94,7 +99,7 @@ def write_variables(app_configs=None, out_file='', git_short=''):
                 region_config = json_configs[env][region]
                 json_configs[env][region] = dict(DeepChainMap(region_config, rendered_configs))
         else:
-            default_pipeline_json = json.loads(get_template('configs/pipeline.json.j2'))
+            default_pipeline_json = json.loads(get_template('configs/pipeline.json.j2', generated=generated))
             json_configs['pipeline'] = dict(DeepChainMap(configs, default_pipeline_json))
 
     LOG.debug('Compiled configs:\n%s', pformat(json_configs))

--- a/src/foremast/iam/create_iam.py
+++ b/src/foremast/iam/create_iam.py
@@ -49,7 +49,8 @@ def create_iam_resources(env='dev', app='', **_):
     LOG.debug('Application details: %s', details)
 
     deployment_type = app_properties['type']
-    role_trust_template = get_template('infrastructure/iam/trust/{0}_role.json.j2'.format(deployment_type))
+    role_trust_template = get_template(
+        'infrastructure/iam/trust/{0}_role.json.j2'.format(deployment_type), generated=generated)
 
     resource_action(
         client,

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -161,7 +161,7 @@ def construct_pipeline_block(env='',
     LOG.debug('Block data:\n%s', pformat(data))
 
     template_name = get_template_name(env, pipeline_type)
-    pipeline_json = get_template(template_file=template_name, data=data)
+    pipeline_json = get_template(template_file=template_name, data=data, generated=generated)
     return pipeline_json
 
 

--- a/src/foremast/pipeline/construct_pipeline_block_datapipeline.py
+++ b/src/foremast/pipeline/construct_pipeline_block_datapipeline.py
@@ -71,5 +71,5 @@ def construct_datapipeline(env='',
 
     LOG.debug('Block data:\n%s', pformat(data))
 
-    pipeline_json = get_template(template_file=template_name, data=data)
+    pipeline_json = get_template(template_file=template_name, data=data, generated=generated)
     return pipeline_json

--- a/src/foremast/pipeline/construct_pipeline_block_lambda.py
+++ b/src/foremast/pipeline/construct_pipeline_block_lambda.py
@@ -90,5 +90,5 @@ def construct_pipeline_block_lambda(env='',
 
     LOG.debug('Block data:\n%s', pformat(data))
 
-    pipeline_json = get_template(template_file=template_name, data=data)
+    pipeline_json = get_template(template_file=template_name, data=data, generated=generated)
     return pipeline_json

--- a/src/foremast/pipeline/construct_pipeline_block_s3.py
+++ b/src/foremast/pipeline/construct_pipeline_block_s3.py
@@ -71,5 +71,5 @@ def construct_pipeline_block_s3(env='',
 
     LOG.debug('Block data:\n%s', pformat(data))
 
-    pipeline_json = get_template(template_file=template_name, data=data)
+    pipeline_json = get_template(template_file=template_name, data=data, generated=generated)
     return pipeline_json

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -136,7 +136,7 @@ class SpinnakerPipeline:
 
         self.log.debug('Wrapper app data:\n%s', pformat(data))
 
-        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data)
+        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data, generated=self.generated)
 
         return json.loads(wrapper)
 

--- a/src/foremast/pipeline/create_pipeline_datapipeline.py
+++ b/src/foremast/pipeline/create_pipeline_datapipeline.py
@@ -70,7 +70,7 @@ class SpinnakerPipelineDataPipeline(SpinnakerPipeline):
 
         self.log.debug('Wrapper app data:\n%s', pformat(data))
 
-        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data)
+        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data, generated=self.generated)
 
         return json.loads(wrapper)
 

--- a/src/foremast/pipeline/create_pipeline_lambda.py
+++ b/src/foremast/pipeline/create_pipeline_lambda.py
@@ -73,7 +73,7 @@ class SpinnakerPipelineLambda(SpinnakerPipeline):
 
         self.log.debug('Wrapper app data:\n%s', pformat(data))
 
-        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data)
+        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data, generated=self.generated)
 
         return json.loads(wrapper)
 

--- a/src/foremast/pipeline/create_pipeline_s3.py
+++ b/src/foremast/pipeline/create_pipeline_s3.py
@@ -73,7 +73,7 @@ class SpinnakerPipelineS3(SpinnakerPipeline):
 
         self.log.debug('Wrapper app data:\n%s', pformat(data))
 
-        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data)
+        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data, generated=self.generated)
 
         return json.loads(wrapper)
 

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -71,8 +71,8 @@ class SpinnakerSecurityGroup(object):
         self.region = region
 
         self.properties = get_properties(properties_file=prop_path, env=self.env, region=self.region)
-        generated = get_details(app=self.app_name)
-        self.group = generated.data['project']
+        self.generated = get_details(app=self.app_name)
+        self.group = self.generated.data['project']
 
     def _validate_cidr(self, rule):
         """Validate the cidr block in a rule.
@@ -223,7 +223,8 @@ class SpinnakerSecurityGroup(object):
             'ingress': ingress,
         }
 
-        secgroup_json = get_template(template_file='infrastructure/securitygroup_data.json.j2', **template_kwargs)
+        secgroup_json = get_template(
+            template_file='infrastructure/securitygroup_data.json.j2', generated=self.generated, **template_kwargs)
 
         wait_for_task(secgroup_json)
         return True

--- a/tests/iam/test_iam_create.py
+++ b/tests/iam/test_iam_create.py
@@ -61,7 +61,7 @@ def test_iam_role_policy(resource_action, get_template, get_properties, get_deta
 
     assert create_iam_resources()
 
-    get_template.assert_called_with(EC2_TEMPLATE_NAME)
+    get_template.assert_called_with(EC2_TEMPLATE_NAME, generated=get_details())
     calls = [
         mock.call(
             mock.ANY,


### PR DESCRIPTION
This allows the object to be accessible to some templates via the `generated` object in jinja.

For example, in `templates/configs/configs.json.j2`, something like this can be added:
```
"lambda_role": {{ generated.app_name() }},
```
This does depend on version 1.9.0 and above of `gogo-utils`.