### PR TITLE
Fix urls after org move

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Spinnaker Foremast
 ==================
 
-.. image:: https://travis-ci.org/gogoair/foremast.svg?branch=master
-    :target: https://travis-ci.org/gogoair/foremast
+.. image:: https://travis-ci.org/foremast/foremast.svg?branch=master
+    :target: https://travis-ci.org/foremast/foremast
 
 .. image:: https://badges.gitter.im/gogoair/foremast.svg
    :alt: Join the chat at https://gitter.im/gogoair/foremast
@@ -205,7 +205,7 @@ defaults. Please take a look at the `application.json`_ docs for all options.
         }
     }
 
-.. _`Foremast templates`: https://github.com/gogoair/foremast-template-examples/
+.. _`Foremast templates`: https://github.com/foremast/foremast-template-examples/
 .. _`quick start guide`: http://foremast.readthedocs.io/en/latest/getting_started.html#quick-start-guide
 .. _`automate spinnaker pipeline creation`: https://tech.gogoair.com/foremast-automate-spinnaker-pipeline-creation-2b2aa7b2c5e4#.qplfw19cg
 .. _`Read the Docs`: http://foremast.readthedocs.io/en/latest/

--- a/_docs/pipeline_examples.rst
+++ b/_docs/pipeline_examples.rst
@@ -112,4 +112,4 @@ internal templates on the `foremast-templates repo`_.
    #. Manual judgment before continuing to the next environment
 
 
-.. _`foremast-templates repo`: https://github.com/gogoair/foremast-template-examples
+.. _`foremast-templates repo`: https://github.com/foremast/foremast-template-examples

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     install_requires=REQUIREMENTS,
     include_package_data=True,
     keywords="aws gogo infrastructure netflixoss python spinnaker",
-    url='https://github.com/gogoair/foremast',
-    download_url='https://github.com/gogoair/foremast',
+    url='https://github.com/foremast/foremast',
+    download_url='https://github.com/foremast/foremast',
     platforms=['OS Independent'],
     license='Apache License (2.0)',
     classifiers=[


### PR DESCRIPTION
This is to fix some of the URLs after the org move from `gogoair/foremast` to `foremast/foremast`.