### PR TITLE
fix: Need "location" in Traffic Guards

### DIFF
--- a/src/foremast/templates/infrastructure/app_data.json.j2
+++ b/src/foremast/templates/infrastructure/app_data.json.j2
@@ -36,7 +36,13 @@
                 ]
             }],
             "trafficGuards": [{% for account_name in pipeline_config.traffic_guards.accounts %}
-                {"account": {{ account_name | tojson }}, "region": "*", "stack": "*", "detail": "*" }
+                {
+                    "account": {{ account_name | tojson }},
+                    "detail": "*",
+                    "location": "*",
+                    "region": "*",
+                    "stack": "*"
+                }
                 {% if not loop.last %},{% endif %}
                 {% endfor %}
             ]


### PR DESCRIPTION
The **Region** field shows up red without the `"location"` specified.