### PR TITLE
Support yaml as application and pipeline config files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ gogo-utils
 jinja2
 murl
 python-gitlab
+pyyaml
 requests
-tryagain
 slacker
+tryagain

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -20,6 +20,7 @@ import os
 from base64 import b64decode
 
 import gitlab
+import yaml
 import requests
 
 from ..consts import AMI_JSON_URL, GIT_URL, GITLAB_TOKEN
@@ -242,9 +243,9 @@ class FileLookup():
         file_contents = self.get(branch=branch, filename=filename)
 
         try:
-            json_dict = json.loads(file_contents)
+            json_dict = yaml.load(file_contents)
         # TODO: Use json.JSONDecodeError when Python 3.4 has been deprecated
-        except ValueError as error:
+        except (ValueError, yaml.parser.ParserError) as error:
             msg = ('"{filename}" appears to be invalid json. '
                    'Please validate it with http://jsonlint.com. '
                    'JSON decoder error:\n'

--- a/tests/utils/test_file_lookups.py
+++ b/tests/utils/test_file_lookups.py
@@ -14,11 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Test Git file lookups."""
-import base64
 from unittest import mock
 
 import pytest
-
 from foremast.exceptions import GitLabApiError
 from foremast.utils import FileLookup
 
@@ -30,7 +28,6 @@ TEST_YAML = '''
 ---
 ship: pirate
 '''
-TEST_JSON_BYTES = TEST_JSON.encode()
 
 
 @mock.patch('foremast.utils.lookups.gitlab')

--- a/tests/utils/test_file_lookups.py
+++ b/tests/utils/test_file_lookups.py
@@ -25,6 +25,11 @@ from foremast.utils import FileLookup
 TEST_JSON = '''{
     "ship": "pirate"
 }'''
+
+TEST_YAML = '''
+---
+ship: pirate
+'''
 TEST_JSON_BYTES = TEST_JSON.encode()
 
 
@@ -54,21 +59,25 @@ def test_project_success(mock_gitlab):
     assert seeker.project is object
 
 
-@mock.patch.object(FileLookup, 'remote_file', return_value=TEST_JSON)
+@pytest.mark.parametrize('datacontent', [TEST_JSON, TEST_YAML])
+@mock.patch.object(FileLookup, 'remote_file')
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_get(gitlab, mock_lookup):
+def test_get(gitlab, mock_lookup, datacontent):
     """Check _get_ method."""
+    mock_lookup.return_value = datacontent
     my_git = FileLookup()
 
     result = my_git.get()
     assert isinstance(result, str)
-    assert TEST_JSON == my_git.get()
+    assert datacontent == my_git.get()
 
 
-@mock.patch.object(FileLookup, 'get', return_value=TEST_JSON)
+@pytest.mark.parametrize('datacontent', [TEST_JSON, TEST_YAML])
+@mock.patch.object(FileLookup, 'get')
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_json(gitlab, mock_lookup):
+def test_json(gitlab, mock_lookup, datacontent):
     """Check _json_ method."""
+    mock_lookup.return_value = datacontent
     my_git = FileLookup()
 
     result = my_git.json()
@@ -76,10 +85,12 @@ def test_json(gitlab, mock_lookup):
     assert result['ship'] == 'pirate'
 
 
-@mock.patch.object(FileLookup, 'get', return_value=TEST_JSON + '}')
+@pytest.mark.parametrize('datacontent', [TEST_JSON, TEST_YAML])
+@mock.patch.object(FileLookup, 'get')
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_invalid_json(gitlab, mock_lookup):
+def test_invalid_json(gitlab, mock_lookup, datacontent):
     """Check invalid JSON."""
+    mock_lookup.return_value = datacontent + '}'
     my_git = FileLookup()
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
This allows yaml files as valid configuration files for `pipeline` and `application-master-$env`.