### PR TITLE
feat: Allow developers to disable manual checkpoints before non-prod stages.

### DIFF
--- a/_docs/configuration_files/pipeline_json/index.rst
+++ b/_docs/configuration_files/pipeline_json/index.rst
@@ -85,6 +85,14 @@ List of accounts that the application will be deployed to. Order matters as it d
     | *Type*: array
     | *Default*: ``["stage", "prod"]``
 
+``checkpoints``
+~~~~~~~~
+
+List of accounts that will have a manual checkpoint stage before them. Order does not matter but these must correspond to the list passed to `env` above. If this option is not present, Foremast places manual checkpoints between all stages by default. A manual checkpoint will never be placed before the first stage. This parameter **does not** affect stages that are built using the ``*_prod_*.json.j2`` templates, which will always contain a manual checkpoint.`
+
+    | *Type*: array
+    | *Default*: ``null``
+
 .. include:: manual.rest
 .. include:: image.rest
 .. include:: lambda.rest

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -159,6 +159,12 @@ def construct_pipeline_block(env='',
         'pipeline': pipeline_data,
     })
 
+    data['do_checkpoint'] = False
+
+    if data['app']['previous_env']:
+        if 'checkpoints' in data['app']['pipeline']:
+            data['do_checkpoint'] = env in data['app']['pipeline']['checkpoints']
+
     LOG.debug('Block data:\n%s', pformat(data))
 
     template_name = get_template_name(env, pipeline_type)

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -164,6 +164,8 @@ def construct_pipeline_block(env='',
     if data['app']['previous_env']:
         if 'checkpoints' in data['app']['pipeline']:
             data['do_checkpoint'] = env in data['app']['pipeline']['checkpoints']
+        else:
+            data['do_checkpoint'] = True
 
     LOG.debug('Block data:\n%s', pformat(data))
 

--- a/src/foremast/templates/pipeline/pipeline_stages.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_stages.json.j2
@@ -1,5 +1,5 @@
 [
-    {% if data.app.previous_env %}
+    {% if data.do_checkpoint %}
     {% include "pipeline/stage-judgement-nonprod.json.j2" %},
     {% endif %}
     {% include "pipeline/stage-infrastructure-setup.json.j2" %},

--- a/src/foremast/templates/pipeline/pipeline_stages_datapipeline.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_stages_datapipeline.json.j2
@@ -1,5 +1,5 @@
 [
-    {% if data.app.previous_env %}
+    {% if data.do_checkpoint %}
     {% include "pipeline/stage-judgement-nonprod.json.j2" %},
     {% endif %}
     {% include "pipeline/stage-infrastructure-setup-datapipeline.json.j2" %}

--- a/src/foremast/templates/pipeline/pipeline_stages_lambda.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_stages_lambda.json.j2
@@ -1,5 +1,5 @@
 [
-    {% if data.app.previous_env %}
+    {% if data.do_checkpoint %}
     {% include "pipeline/stage-judgement-nonprod.json.j2" %},
     {% endif %}
     {% include "pipeline/stage-infrastructure-setup-lambda.json.j2" %},

--- a/src/foremast/templates/pipeline/pipeline_stages_s3.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_stages_s3.json.j2
@@ -1,5 +1,5 @@
 [
-    {% if data.app.previous_env %}
+    {% if data.do_checkpoint %}
     {% include "pipeline/stage-judgement-nonprod.json.j2" %},
     {% endif %}
     {% include "pipeline/stage-infrastructure-setup-s3.json.j2" %},


### PR DESCRIPTION
Added and documented a new `pipeline.json` parameter:

`checkpoints`: List of accounts that will have a manual checkpoint stage before them. Order does not matter but these must correspond to the list passed to `env` above. If this option is not present, Foremast places manual checkpoints between all stages by default. A manual checkpoint will never be placed before the first stage. This parameter **does not** affect stages that are built using the ``*_prod_*.json.j2`` templates, which will always contain a manual checkpoint.