### PR TITLE
Latest Spinnaker release returns additional results with missing keys

### DIFF
--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -155,7 +155,7 @@ def _convert_string_to_native(value):
     result = None
 
     try:
-        result = ast.literal_eval(value)
+        result = ast.literal_eval(str(value))
     except (SyntaxError, ValueError):
         # Likely a string
         result = value.split(',')

--- a/src/foremast/utils/subnets.py
+++ b/src/foremast/utils/subnets.py
@@ -57,11 +57,10 @@ def get_subnets(
         raise SpinnakerTimeout(subnet_response.text)
 
     subnet_list = subnet_response.json()
-
     for subnet in subnet_list:
         LOG.debug('Subnet: %(account)s\t%(region)s\t%(target)s\t%(vpcId)s\t' '%(availabilityZone)s', subnet)
 
-        if subnet['target'] == target:
+        if 'target' in subnet and subnet['target'] == target:
             availability_zone = subnet['availabilityZone']
             account = subnet['account']
             subnet_region = subnet['region']

--- a/src/foremast/utils/subnets.py
+++ b/src/foremast/utils/subnets.py
@@ -60,7 +60,7 @@ def get_subnets(
     for subnet in subnet_list:
         LOG.debug('Subnet: %(account)s\t%(region)s\t%(target)s\t%(vpcId)s\t' '%(availabilityZone)s', subnet)
 
-        if 'target' in subnet and subnet['target'] == target:
+        if subnet.get('target', '') == target:
             availability_zone = subnet['availabilityZone']
             account = subnet['account']
             subnet_region = subnet['region']

--- a/src/foremast/utils/vpc.py
+++ b/src/foremast/utils/vpc.py
@@ -41,7 +41,7 @@ def get_vpc_id(account, region):
             configured.
 
     """
-    url = '{0}/vpcs'.format(API_URL)
+    url = '{0}/networks/aws'.format(API_URL)
     response = requests.get(url, verify=GATE_CA_BUNDLE, cert=GATE_CLIENT_CERT)
 
     if not response.ok:

--- a/src/foremast/utils/vpc.py
+++ b/src/foremast/utils/vpc.py
@@ -51,7 +51,7 @@ def get_vpc_id(account, region):
 
     for vpc in vpcs:
         LOG.debug('VPC: %(name)s, %(account)s, %(region)s => %(id)s', vpc)
-        if all([vpc['name'] == 'vpc', vpc['account'] == account, vpc['region'] == region]):
+        if 'name' in vpc and all([vpc['name'] == 'vpc', vpc['account'] == account, vpc['region'] == region]):
             LOG.info('Found VPC ID for %s in %s: %s', account, region, vpc['id'])
             vpc_id = vpc['id']
             break


### PR DESCRIPTION
Latest version of Spinnaker is returning additional subnets and VPCs. We have a strict conditional on specific key/values being present, and they might not always be present.

In addition, fixing issue with ast.literal_eval. Running into a reported bug after upgrading system Python to Python 3.7.2