### PR TITLE
feat: Added support for custom runway directory name

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -107,6 +107,18 @@ relative to where you where you are running the Foremast commands. See
 
     | *Required*: No
 
+``runway_base_path``
+******************
+
+Base path to use when looking for custom runway directories. If provided,
+Foremast will first look for Foremast runway files in this directory. 
+This is useful if you have a different folder or location to store pipeline
+configuration values.
+
+    | *Type*: str
+    | *Default*: ``runway``
+    | *Required*: No
+
 ``default_run_as_user``
 ***********************
 

--- a/src/foremast/configs/prepare_configs.py
+++ b/src/foremast/configs/prepare_configs.py
@@ -17,7 +17,7 @@
 import collections
 import logging
 
-from ..consts import ENVS, REGIONS
+from ..consts import ENVS, REGIONS, RUNWAY_BASE_PATH
 from ..utils import DeepChainMap, FileLookup
 
 LOG = logging.getLogger(__name__)
@@ -36,7 +36,9 @@ def process_git_configs(git_short=''):
     """
     LOG.info('Processing application.json files from GitLab "%s".', git_short)
     file_lookup = FileLookup(git_short=git_short)
-    app_configs = process_configs(file_lookup, 'runway/application-master-{env}.json', 'runway/pipeline.json')
+    app_configs = process_configs(file_lookup,
+                                  RUNWAY_BASE_PATH + '/application-master-{env}.json',
+                                  RUNWAY_BASE_PATH + '/pipeline.json')
     commit_obj = file_lookup.project.commits.get('master')
     config_commit = commit_obj.attributes['id']
     LOG.info('Commit ID used: %s', config_commit)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -199,6 +199,7 @@ ENVS = set(validate_key_values(CONFIG, 'base', 'envs', default='').split(','))
 REGIONS = set(validate_key_values(CONFIG, 'base', 'regions', default='').split(','))
 ALLOWED_TYPES = set(
     validate_key_values(CONFIG, 'base', 'types', default='ec2,lambda,s3,datapipeline,rolling').split(','))
+RUNWAY_BASE_PATH = validate_key_values(CONFIG, 'base', 'runway_base_path', default='runway')
 TEMPLATES_PATH = validate_key_values(CONFIG, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(CONFIG, 'base', 'ami_json_url')
 DEFAULT_RUN_AS_USER = validate_key_values(CONFIG, 'base', 'default_run_as_user', default=None)

--- a/src/foremast/pipeline/clean_pipelines.py
+++ b/src/foremast/pipeline/clean_pipelines.py
@@ -19,7 +19,7 @@ import logging
 import murl
 import requests
 
-from ..consts import API_URL, GATE_CA_BUNDLE, GATE_CLIENT_CERT
+from ..consts import API_URL, GATE_CA_BUNDLE, GATE_CLIENT_CERT, RUNWAY_BASE_PATH
 from ..exceptions import SpinnakerPipelineCreationFailed, SpinnakerPipelineDeletionFailed
 from ..utils import check_managed_pipeline, get_all_pipelines, normalize_pipeline_name
 
@@ -77,7 +77,8 @@ def clean_pipelines(app='', settings=None):
         try:
             regions.update(settings[env]['regions'])
         except KeyError:
-            raise SpinnakerPipelineCreationFailed('Missing "runway/application-master-{0}.json".'.format(env))
+            error_msg = 'Missing "{}/application-master-{}.json".'.format(RUNWAY_BASE_PATH, env)
+            raise SpinnakerPipelineCreationFailed(error_msg)
     LOG.debug('Regions defined: %s', regions)
 
     for pipeline in pipelines:

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -17,8 +17,8 @@
 from configparser import ConfigParser
 from unittest.mock import patch
 
-from foremast.consts import (ALLOWED_TYPES, DEFAULT_SECURITYGROUP_RULES, EC2_PIPELINE_TYPES, _generate_security_groups,
-                             extract_formats)
+from foremast.consts import (ALLOWED_TYPES, DEFAULT_SECURITYGROUP_RULES, EC2_PIPELINE_TYPES, RUNWAY_BASE_PATH,
+                             _generate_security_groups, extract_formats, validate_key_values)
 
 
 def test_consts_extract_formats():
@@ -68,3 +68,13 @@ def test_parse_ec2_pipeline_types():
     """Validate EC2 Pipeline Types."""
     assert EC2_PIPELINE_TYPES == ('ec2', 'rolling')
     assert isinstance(EC2_PIPELINE_TYPES, tuple)
+
+def test_consts_default_runway_base_path():
+    """Validate default runway base path remains unchanged"""
+    assert RUNWAY_BASE_PATH == 'runway'
+
+def test_consts_custom_runway_base_path():
+    """Validate custom runway base path changes as expected"""
+    sample_config = {'base': {'runway_base_path': 'custom'}}
+    result = validate_key_values(sample_config, 'base', 'runway_base_path', default='runway')
+    assert result == 'custom'


### PR DESCRIPTION
Not everyone will call their application repo "runway/", this enables folks to override this while still retaining the default "runway/" behavior today.