### PR TITLE
Lambda Docs: Timeout Invalid

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -125,10 +125,11 @@ Override the default generated IAM Role name.
 ``lambda_timeout``
 ******************
 
-The timeout setting for Lambda function
+The timeout setting for Lambda function. See official limits
+https://docs.aws.amazon.com/lambda/latest/dg/limits.html
 
     | *Type*: string
-    | *Default*: ``"3600"``
+    | *Default*: ``"900"``
     | *Units*: Seconds
 
 ``asg`` Block


### PR DESCRIPTION
The default timeout is not 3600, you can't even specify more than 900 currently. Added a doc in case AWS increases the timeout as well.