### PR TITLE
adding support to allow data pipeline in service block 

### DIFF
--- a/_docs/configuration_files/pipeline_json/services.rest
+++ b/_docs/configuration_files/pipeline_json/services.rest
@@ -37,6 +37,14 @@ Add CloudWatch Limited access.
    | *Type*: boolean
    | *Default*: ``false``
 
+``datapipeline``
+*******
+
+Allows a data pipeline to be trigger e.g. via lambda.
+
+   | *Type*: boolean
+   | *Default*: ``false``
+
 ``dynamodb``
 ************
 

--- a/src/foremast/templates/infrastructure/iam/datapipeline.json.j2
+++ b/src/foremast/templates/infrastructure/iam/datapipeline.json.j2
@@ -1,0 +1,8 @@
+ {
+            "Sid": "DataPipelineActivate",
+            "Effect": "Allow",
+            "Action": [
+                "datapipeline:ActivatePipeline"
+            ],
+            "Resource": "*"
+}


### PR DESCRIPTION
To have an event driven architecture its cool to use AWS lambda. When an S3 object is pushed today support is not available to activate a data pipeline. 

This new feature will add the capability. 