### PR TITLE
fix: Added 'manual' pipeline type to default allowed types

### DIFF
--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -198,7 +198,7 @@ DOMAIN = validate_key_values(CONFIG, 'base', 'domain', default='example.com')
 ENVS = set(validate_key_values(CONFIG, 'base', 'envs', default='').split(','))
 REGIONS = set(validate_key_values(CONFIG, 'base', 'regions', default='').split(','))
 ALLOWED_TYPES = set(
-    validate_key_values(CONFIG, 'base', 'types', default='ec2,lambda,s3,datapipeline,rolling').split(','))
+    validate_key_values(CONFIG, 'base', 'types', default='ec2,lambda,s3,datapipeline,rolling,manual').split(','))
 RUNWAY_BASE_PATH = validate_key_values(CONFIG, 'base', 'runway_base_path', default='runway')
 TEMPLATES_PATH = validate_key_values(CONFIG, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(CONFIG, 'base', 'ami_json_url')


### PR DESCRIPTION
Pipeline type "manual" is supported and included in documentation, however it is not in the default allowed pipeline types resulting in an exception when trying to use the feature.  This PR adds the manual pipeline type to the allowed pipelines.