### PR TITLE
fix: Unknown values in logging

### DIFF
--- a/src/foremast/utils/subnets.py
+++ b/src/foremast/utils/subnets.py
@@ -58,7 +58,7 @@ def get_subnets(
 
     subnet_list = subnet_response.json()
     for subnet in subnet_list:
-        LOG.debug('Subnet: %(account)s\t%(region)s\t%(target)s\t%(vpcId)s\t' '%(availabilityZone)s', subnet)
+        LOG.debug('Subnet Response: %s', subnet)
 
         if subnet.get('target', '') == target:
             availability_zone = subnet['availabilityZone']

--- a/src/foremast/utils/vpc.py
+++ b/src/foremast/utils/vpc.py
@@ -50,7 +50,7 @@ def get_vpc_id(account, region):
     vpcs = response.json()
 
     for vpc in vpcs:
-        LOG.debug('VPC: %(name)s, %(account)s, %(region)s => %(id)s', vpc)
+        LOG.debug('VPC Response: %s', vpc)
         if 'name' in vpc and all([vpc['name'] == 'vpc', vpc['account'] == account, vpc['region'] == region]):
             LOG.info('Found VPC ID for %s in %s: %s', account, region, vpc['id'])
             vpc_id = vpc['id']


### PR DESCRIPTION
In both cases, we are trying to log keys that might not exist. 

Spinnaker's response has come a long way since this was implemented and offers quite a bit of what we were doing here. Logging the response body looks like:

`{"account":"some_account", "cloudProvider":"some_provider", "deprecated":false, "id":"some-vpcid", "name":"some_tag_name", "region":"some_region"}`