### PR TITLE
fix: don't overwrite s3 triggers set by other lambdas

### DIFF
--- a/src/foremast/awslambda/s3_event/s3_event.py
+++ b/src/foremast/awslambda/s3_event/s3_event.py
@@ -64,6 +64,10 @@ def create_s3_event(app_name, env, region, bucket, triggers):
         for trigger in old_config["LambdaFunctionConfigurations"]:
             if trigger["LambdaFunctionArn"] != lambda_alias_arn:
                 config_json["LambdaFunctionConfigurations"].append(trigger)
+    if "QueueConfigurations" in old_config:
+        config_json["QueueConfigurations"] = old_config["QueueConfigurations"]
+    if "TopicConfigurations" in old_config:
+        config_json["TopicConfigurations"] = old_config["TopicConfigurations"]
 
     s3_client.put_bucket_notification_configuration(Bucket=bucket, NotificationConfiguration=config_json)
 


### PR DESCRIPTION
**Problem:** Foremast uses the [put_bucket_notification_configuration](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-notification-configuration.html) method of the AWS CLI to configure s3-based triggers for Lambda functions. This method does not upsert, but overwrites all triggers on the bucket.

**Solution:** Pull the current notification configuration and parse it for any triggers not set by this Lambda function. Copy those triggers into the new configuration.

**Caveat:** This may result in Foremast attempting to create two triggers with the same filter, causing an error.

**Possible Enhancement:** Copy the SQS and SNS triggers to ensure that they are preserved as well.