### PR TITLE
adding bucket_name for deploy option

### DIFF
--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -58,6 +58,8 @@ class S3Deployment:
             newgenerated = get_details(app=shared_app, env=env, region=region)
             self.bucket = newgenerated.shared_s3_app_bucket(include_region=include_region)
             self.s3path = app
+        elif self.s3props.get('bucket_name'):
+            self.bucket = self.s3props['bucket_name']
         else:
             self.bucket = generated.s3_app_bucket(include_region=include_region)
             self.s3path = self.s3props['path'].lstrip('/')


### PR DESCRIPTION
The new feature for s3 pipeline added ability to override name with existing s3 buckets. However, it missed the s3deploy step. 