### PR TITLE
Fixed bug causing incorrect config py to be loaded

### DIFF
--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -106,6 +106,8 @@ def load_dynamic_config(config_file=DEFAULT_DYNAMIC_CONFIG_FILE):
     except ImportError:
         # Provide a default if config not found
         LOG.error('ImportError: Unable to load dynamic config. Check config.py file imports!')
+    except AttributeError:
+        LOG.error('AttributeError: Unable to load CONFIG from %s', config_file)
 
     return dynamic_configurations
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -29,6 +29,7 @@ import ast
 import json
 import logging
 import sys
+import importlib.util
 from configparser import ConfigParser
 from os import getcwd, getenv, path
 from os.path import exists, expanduser, expandvars
@@ -98,9 +99,10 @@ def load_dynamic_config(config_file=DEFAULT_DYNAMIC_CONFIG_FILE):
     # Insert config path so we can import it
     sys.path.insert(0, path.dirname(path.abspath(config_file)))
     try:
-        config_module = __import__('config')
-
-        dynamic_configurations = config_module.CONFIG
+        config_file_spec = importlib.util.spec_from_file_location("config", config_file)
+        config_file_module = importlib.util.module_from_spec(config_file_spec)
+        config_file_spec.loader.exec_module(config_file_module)
+        dynamic_configurations = config_file_module.CONFIG
     except ImportError:
         # Provide a default if config not found
         LOG.error('ImportError: Unable to load dynamic config. Check config.py file imports!')


### PR DESCRIPTION
When setting `FOREMAST_CONFIG_FILE=config2.py` I noticed it was still always loading `config.py`.  

The code to import the 'config' module was adding the config2.py's directory then loading the module, but since both config2.py and config.py are in the same directory (in my case) the incorrect one was loaded.  

This PR fixes the bug by loading the config module from a filepath rather than a directory.

The solution only works in Python 3.5+ according to [StackOverflow](https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path).  