### PR TITLE
Added util function for Google Identity Aware Proxy tokens

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ python-gitlab
 requests
 slacker
 tryagain
+google-auth==1.6.2
+requests_toolbelt==0.9.1
+PyJWT==1.7.1
+cryptography==2.5

--- a/src/foremast/utils/google_iap.py
+++ b/src/foremast/utils/google_iap.py
@@ -2,16 +2,15 @@ import google.auth
 import google.auth.app_engine
 import google.auth.compute_engine.credentials
 import google.auth.iam
-from google.auth.transport.requests import Request
+from google.auth.transport.requests import Request as GoogleAuthRequest
 import google.oauth2.credentials
 import google.oauth2.service_account
-import requests
-import requests_toolbelt.adapters.appengine
 import logging
 
-GOOGLE_IAP_IAM_SCOPE = 'https://www.googleapis.com/auth/iam' # Used in request to Google for OIDC Scope
-GOOGLE_OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token' # Endpoint for getting tokens for Id Aware Proxy
+GOOGLE_IAP_IAM_SCOPE = 'https://www.googleapis.com/auth/iam'  # Used in request to Google for OIDC Scope
+GOOGLE_OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'  # Endpoint for getting tokens for Id Aware Proxy
 LOG = logging.getLogger(__name__)
+
 
 def get_google_iap_bearer_token(client_id, key_path):
     """Makes a request to an application protected by Identity-Aware Proxy.
@@ -39,13 +38,12 @@ def get_google_iap_bearer_token(client_id, key_path):
             'target_audience': client_id
         })
 
-    # Create jtw signed by svc account.  This is sent to Google to get a 
-    # GOOGLE SIGNED jwt token
+    # Create jtw signed by svc account.  This is sent to Google to get a Google signed jwt token
     LOG.debug("Getting service account JWT from endpoint %s", GOOGLE_OAUTH_TOKEN_URI)
     service_account_jwt = (
         service_account_credentials._make_authorization_grant_assertion())
     # Get Google Signed JWT Token
-    request = google.auth.transport.requests.Request()
+    request = GoogleAuthRequest()
     body = {
         'assertion': service_account_jwt,
         'grant_type': google.oauth2._client._JWT_GRANT_TYPE,

--- a/src/foremast/utils/google_iap.py
+++ b/src/foremast/utils/google_iap.py
@@ -20,7 +20,7 @@ def get_google_iap_bearer_token(client_id, key_path):
       key_path: Path to Google Cloud Service Account Credentials in JSON Format
 
     Returns:
-      The JWT Bearer Token
+      Mapping[str, str]: The JSON-decoded response data.
     """
 
     LOG.debug("Parsing Google Cloud Service Account credentials")
@@ -48,6 +48,5 @@ def get_google_iap_bearer_token(client_id, key_path):
         'assertion': service_account_jwt,
         'grant_type': google.oauth2._client._JWT_GRANT_TYPE,
     }
-    token_response = google.oauth2._client._token_endpoint_request(
-        request, GOOGLE_OAUTH_TOKEN_URI, body)
-    return token_response['id_token']
+
+    return google.oauth2._client._token_endpoint_request(request, GOOGLE_OAUTH_TOKEN_URI, body)

--- a/src/foremast/utils/google_iap.py
+++ b/src/foremast/utils/google_iap.py
@@ -1,0 +1,55 @@
+import google.auth
+import google.auth.app_engine
+import google.auth.compute_engine.credentials
+import google.auth.iam
+from google.auth.transport.requests import Request
+import google.oauth2.credentials
+import google.oauth2.service_account
+import requests
+import requests_toolbelt.adapters.appengine
+import logging
+
+GOOGLE_IAP_IAM_SCOPE = 'https://www.googleapis.com/auth/iam' # Used in request to Google for OIDC Scope
+GOOGLE_OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token' # Endpoint for getting tokens for Id Aware Proxy
+LOG = logging.getLogger(__name__)
+
+def get_google_iap_bearer_token(client_id, key_path):
+    """Makes a request to an application protected by Identity-Aware Proxy.
+
+    Args:
+      client_id: The OpenID Connect client ID used by Identity-Aware Proxy.
+      key_path: Path to Google Cloud Service Account Credentials in JSON Format
+
+    Returns:
+      The JWT Bearer Token
+    """
+
+    LOG.debug("Parsing Google Cloud Service Account credentials")
+    # Load the json svc account credentials
+    creds_from_json = google.oauth2.service_account.Credentials.from_service_account_file(
+        key_path,
+        scopes=[GOOGLE_IAP_IAM_SCOPE],
+    )
+
+    LOG.debug("Parsed Google Cloud Service Account credentials with email %s", creds_from_json.signer_email)
+    # Construct OAuth 2.0 service account credentials using the signer
+    # and email acquired from the json creds file
+    service_account_credentials = google.oauth2.service_account.Credentials(
+        creds_from_json.signer, creds_from_json.signer_email, token_uri=GOOGLE_OAUTH_TOKEN_URI, additional_claims={
+            'target_audience': client_id
+        })
+
+    # Create jtw signed by svc account.  This is sent to Google to get a 
+    # GOOGLE SIGNED jwt token
+    LOG.debug("Getting service account JWT from endpoint %s", GOOGLE_OAUTH_TOKEN_URI)
+    service_account_jwt = (
+        service_account_credentials._make_authorization_grant_assertion())
+    # Get Google Signed JWT Token
+    request = google.auth.transport.requests.Request()
+    body = {
+        'assertion': service_account_jwt,
+        'grant_type': google.oauth2._client._JWT_GRANT_TYPE,
+    }
+    token_response = google.oauth2._client._token_endpoint_request(
+        request, GOOGLE_OAUTH_TOKEN_URI, body)
+    return token_response['id_token']


### PR DESCRIPTION
Google Cloud supports a partially automated deployment of Spinnaker using Google Identity Aware Proxy for authentication.   There is only one Gate endpoint available, making it difficult to support Google IAP and x509 Auth.

This PR adds a util function to authenticate against Google IAP using an appropriately configured Google Cloud Service Account.  The function returns the a JWT which can be used to authenticate against Spinnaker.

Usage:

```python
svc_account_creds_path='/my/path/svc-account.json'
iap_client_id ='my-client-id-from-google'
my_token = get_google_iap_bearer_token(iap_client_id, svc_account_creds_path)
```