### PR TITLE
refactor: Removed support for Python versions 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ cache: false
 
 matrix:
   include:
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,lint
+envlist = py36,py37,lint
 skip_missing_interpreters = True
 
 [pytest]


### PR DESCRIPTION
After discussion, we are dropping support for Python 3.4. If there is no strong disagreement, we should consider 3.5. Thoughts?