### PR TITLE
adding initial support for dlq

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -82,8 +82,20 @@ https://aws.amazon.com/ec2/instance-types/ for details
 
 A dead letter queue configuration that specifies the queue or topic where Lambda sends asynchronous events when they fail processing 
 
-    | *Type*: string
-    | *Default*: ``""``
+Dead Letter Queues are supported in either SNS or SQS and pass in the ARN. See https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html for more details
+
+    | *Type*: array
+    | *Default*: ``[]``
+
+``lambda_dlq`` *Example*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+   "lambda_dlq": {
+            "TargetArn": "arn:aws:sns:us-east-1:accountnumber:topic"
+        }
+
 
 ``lambda_environment``
 **********************

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -77,6 +77,14 @@ https://aws.amazon.com/ec2/instance-types/ for details
     | *Type*: string
     | *Default*: ``"t2.micro"``
 
+``lambda_dlq``
+*****************
+
+A dead letter queue configuration that specifies the queue or topic where Lambda sends asynchronous events when they fail processing 
+
+    | *Type*: string
+    | *Default*: ``""``
+
 ``lambda_environment``
 **********************
 

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -185,7 +185,7 @@ class LambdaFunction:
                 MemorySize=int(self.memory),
                 VpcConfig=vpc_config,
                 Layers=self.lambda_layers,
-                DeadLetterConfig={'TargetArn': self.lambda_dlq})
+                DeadLetterConfig=self.lambda_dlq)
 
             if self.concurrency_limit:
                 self.lambda_client.put_function_concurrency(
@@ -247,7 +247,7 @@ class LambdaFunction:
                 Tags={'app_group': self.group,
                       'app_name': self.app_name},
                 Layers=self.lambda_layers,
-                DeadLetterConfig={'TargetArn': self.lambda_dlq})
+                DeadLetterConfig=self.lambda_dlq)
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:
                 message = '{0} is missing "ec2:CreateNetworkInterface"'.format(self.role_arn)

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -185,7 +185,7 @@ class LambdaFunction:
                 MemorySize=int(self.memory),
                 VpcConfig=vpc_config,
                 Layers=self.lambda_layers,
-                DeadLetterConfig={'TargetArn': self.lambda_dlq   })
+                DeadLetterConfig={'TargetArn':self.lambda_dlq})
 
             if self.concurrency_limit:
                 self.lambda_client.put_function_concurrency(
@@ -247,7 +247,7 @@ class LambdaFunction:
                 Tags={'app_group': self.group,
                       'app_name': self.app_name},
                 Layers=self.lambda_layers,
-                DeadLetterConfig={'TargetArn': self.lambda_dlq   })
+                DeadLetterConfig={'TargetArn':self.lambda_dlq})
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:
                 message = '{0} is missing "ec2:CreateNetworkInterface"'.format(self.role_arn)

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -60,6 +60,7 @@ class LambdaFunction:
         app = self.settings['app']
         self.lambda_environment = app['lambda_environment']
         self.lambda_layers = app['lambda_layers']
+        self.lambda_dlq = app['lambda_dlq']
         self.memory = app['lambda_memory']
         self.role = app.get('lambda_role') or generated.iam()['lambda_role']
         self.timeout = app['lambda_timeout']
@@ -183,7 +184,8 @@ class LambdaFunction:
                 Timeout=int(self.timeout),
                 MemorySize=int(self.memory),
                 VpcConfig=vpc_config,
-                Layers=self.lambda_layers)
+                Layers=self.lambda_layers,
+                DeadLetterConfig={'TargetArn': self.lambda_dlq   })
 
             if self.concurrency_limit:
                 self.lambda_client.put_function_concurrency(
@@ -244,7 +246,8 @@ class LambdaFunction:
                 VpcConfig=vpc_config,
                 Tags={'app_group': self.group,
                       'app_name': self.app_name},
-                Layers=self.lambda_layers)
+                Layers=self.lambda_layers,
+                DeadLetterConfig={'TargetArn': self.lambda_dlq   })
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:
                 message = '{0} is missing "ec2:CreateNetworkInterface"'.format(self.role_arn)

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -185,7 +185,7 @@ class LambdaFunction:
                 MemorySize=int(self.memory),
                 VpcConfig=vpc_config,
                 Layers=self.lambda_layers,
-                DeadLetterConfig={'TargetArn':self.lambda_dlq})
+                DeadLetterConfig={'TargetArn': self.lambda_dlq})
 
             if self.concurrency_limit:
                 self.lambda_client.put_function_concurrency(
@@ -247,7 +247,7 @@ class LambdaFunction:
                 Tags={'app_group': self.group,
                       'app_name': self.app_name},
                 Layers=self.lambda_layers,
-                DeadLetterConfig={'TargetArn':self.lambda_dlq})
+                DeadLetterConfig={'TargetArn': self.lambda_dlq})
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:
                 message = '{0} is missing "ec2:CreateNetworkInterface"'.format(self.role_arn)

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -6,6 +6,7 @@
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",
         "instance_type": "t2.micro",
+        "lambda_dlq": {},
         "lambda_environment": {},
         "lambda_layers": [],
         "lambda_memory": "128",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -6,7 +6,7 @@
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",
         "instance_type": "t2.micro",
-        "lambda_dlq": null,
+        "lambda_dlq": [],
         "lambda_environment": {},
         "lambda_layers": [],
         "lambda_memory": "128",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -6,7 +6,7 @@
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",
         "instance_type": "t2.micro",
-        "lambda_dlq": {},
+        "lambda_dlq": null,
         "lambda_environment": {},
         "lambda_layers": [],
         "lambda_memory": "128",

--- a/tests/lambda/test_aws.py
+++ b/tests/lambda/test_aws.py
@@ -18,6 +18,7 @@ TEST_PROPERTIES = {
         'lambda_timeout': 0,
         'lambda_environment': None,
         'lambda_layers': None,
+        'lambda_dlq': None,
     }
 }
 GENERATED_IAM = {

--- a/tests/lambda/test_event.py
+++ b/tests/lambda/test_event.py
@@ -56,6 +56,7 @@ def get_properties_with_triggers(triggers):
             'lambda_timeout': 0,
             'lambda_environment': None,
             'lambda_layers': None,
+            'lambda_dlq': None,
         },
         "lambda_triggers": triggers
     }


### PR DESCRIPTION
Currently foremast does not support Dead Letter Queue Configuration as part of Lambda Pipeline. 

A key challenge that Lambda users will face in the pipeline is the handling of exceptions. Some examples include:

- Notifications of when a function fails e.g. via an SNS handler
- Queue messages that can be reviewed by developers for root cause such as SQS

