### PR TITLE
fix: Unneeded loop of accounts on app creation

### DIFF
--- a/src/foremast/app/aws.py
+++ b/src/foremast/app/aws.py
@@ -17,7 +17,10 @@ class SpinnakerApp(base.BaseApp):
             AssertionError: Application creation failed.
 
         """
-        self.appinfo['accounts'] = self.get_accounts()
+
+        # Retaining abstract account list for backwards compatability
+        # Refer to #366
+        self.appinfo['accounts'] = ['default']
         self.log.debug('Pipeline Config\n%s', pformat(self.pipeline_config))
         self.log.debug('App info:\n%s', pformat(self.appinfo))
         jsondata = self.render_application_template()

--- a/src/foremast/templates/infrastructure/app_data.json.j2
+++ b/src/foremast/templates/infrastructure/app_data.json.j2
@@ -1,9 +1,7 @@
 {
 "job": [
-    {%for account in appinfo.accounts %}
     {
         "type":"createApplication",
-        "account":"{{ account.name }}",
         "application":{
             "cloudProviders":"aws",
             "name": "{{ appinfo.app }}",
@@ -48,9 +46,8 @@
             ]
         },
         "user": "foremast"
-    }{% if not loop.last %},{% endif %}
-    {% endfor %}
+    }
   ],
-"application": "{{ appinfo.app }}",
-"description": "Created application {{ appinfo.app }}"
+  "application": "{{ appinfo.app }}",
+  "description": "Created application {{ appinfo.app }}"
 }


### PR DESCRIPTION
Looking at the latest Spinnaker Release, the create application call does not expect an iterated loop of accounts. This is breaking some extensions when it comes to manual pipelines. In order to retain backwards compatibility we are leaving a default list of accounts but this isn't used. Here is the most recent JSON payload to createApplication:

```{
    "job": [
        {
            "type": "createApplication",
            "application": {
                "cloudProviders": "aws",
                "instancePort": 80,
                "providerSettings": {
                    "aws": {
                        "useAmiBlockDeviceMappings": false
                    }
                },
                "name": "testapp",
                "email": "test@test.com",
                "description": "Test"
            },
            "user": "example@example.com"
        }
    ],
    "application": "testapp",
    "description": "Create Application: testapp"
}
```