### PR TITLE
adding docs for concurrency limits

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -77,6 +77,15 @@ https://aws.amazon.com/ec2/instance-types/ for details
     | *Type*: string
     | *Default*: ``"t2.micro"``
 
+``lambda_concurrency_limit``
+**********************
+
+Each region in your AWS account has a Lambda concurrency limit. The concurrency limit determines how many function invocations can run simultaneously in one region. The limit applies to all functions in the same region and is set to 1000 by default.
+
+If you exceed a concurrency limit, Lambda starts throttling the offending functions by rejecting requests. Depending on the invocation type, you’ll run into the following situations:
+
+More info on limits can be found here: https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+
 ``lambda_dlq``
 *****************
 


### PR DESCRIPTION
For some reason docs were missing lambda_concurreny_limit docs. Add details to help educate users