### PR TITLE
feat: Lambda Event Pattern Support

### DIFF
--- a/_docs/lambda/lambda_events.rst
+++ b/_docs/lambda/lambda_events.rst
@@ -27,14 +27,14 @@ This example would go in the :ref:`application_json` configuration file.
        {
          "type": "cloudwatch-event",
          "rule_name": "app cron - 5min",
-         "rule_type": "schedule"
+         "rule_type": "schedule",
          "rule_description": "triggers lambda function every five minutes",
          "schedule": "rate(5 minutes)"
        },
        {
          "type": "cloudwatch-event",
          "rule_name": "GuardDutyEvents",
-         "rule_type": "event_pattern"
+         "rule_type": "event_pattern",
          "rule_description": "Trigger Lambda Function for every AWS GuardDutyEvent",
          "event_pattern": {"source": ["aws.guardduty"]}
        },

--- a/_docs/lambda/lambda_events.rst
+++ b/_docs/lambda/lambda_events.rst
@@ -26,9 +26,17 @@ This example would go in the :ref:`application_json` configuration file.
        },
        {
          "type": "cloudwatch-event",
-         "schedule": "rate(5 minutes)",
          "rule_name": "app cron - 5min",
-         "rule_description": "triggers lambda function every five minutes"
+         "rule_type": "schedule"
+         "rule_description": "triggers lambda function every five minutes",
+         "schedule": "rate(5 minutes)"
+       },
+       {
+         "type": "cloudwatch-event",
+         "rule_name": "GuardDutyEvents",
+         "rule_type": "event_pattern"
+         "rule_description": "Trigger Lambda Function for every AWS GuardDutyEvent",
+         "event_pattern": {"source": ["aws.guardduty"]}
        },
        {
          "type": "cloudwatch-logs",
@@ -125,10 +133,86 @@ Sets up an API Gatway event to trigger a lambda function.
         | *Required*: True
         | *Example*: ``"GET"``
 
-``cloudwatch-event`` Trigger *Keys*
-===================================
+``cloudwatch-event`` Event Pattern Trigger *Keys*
+=================================================
 
-A Cloudwatch Scheduled event for Lambda triggers.
+A CloudWatch event pattern for Lambda triggers.
+
+``rule_name``
+^^^^^^^^^^^^^
+
+    The name of the CloudWatch rule being created.
+
+        | *Type*: string
+        | *Required*: True
+
+``rule_type``
+^^^^^^^^^^^^^
+
+    Type of CloudWatch Rule to create, must be set to ``"event_pattern"`` for Event Pattern Triggers.
+
+        | *Type*: string
+        | *Required*: True
+        | *Default*: ``"schedule"``
+        | *Values*:
+
+            - ``"schedule"``
+            - ``"event_pattern"``
+
+``rule_description``
+^^^^^^^^^^^^^^^^^^^^
+
+    Description of the rule being created.
+
+        | *Type*: string
+        | *Required*: False
+
+``event_pattern``
+^^^^^^^^^^^^^^^^^
+
+    CloudWatch Rule Event Pattern JSON. Usage Help can be found using the CloudWatch Rule GUI or the Docs:
+    https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
+
+        | *Type*: string
+        | *Required*: True
+        | *Examples*:
+
+            - ``{"source": ["aws.guardduty"]}``
+            - ``{"source": [ "aws.ec2" ], "detail-type": ["EC2 Instance State-change Notification"], "detail": {"state": ["running"]}}``
+
+``cloudwatch-event`` Schedule Trigger *Keys*
+============================================
+
+A CloudWatch Scheduled event for Lambda triggers.
+
+``rule_name``
+^^^^^^^^^^^^^
+
+    The name of the CloudWatch rule being created.
+
+        | *Type*: string
+        | *Required*: True
+
+``rule_type``
+^^^^^^^^^^^^^
+
+    Type of CloudWatch Rule to create
+
+        | *Type*: string
+        | *Required*: False
+        | *Default*: ``"schedule"``
+        | *Values*:
+
+            - ``"schedule"``
+            - ``"event_pattern"``
+
+``rule_description``
+^^^^^^^^^^^^^^^^^^^^
+
+    Description of the rule being created.
+
+        | *Type*: string
+        | *Required*: False
 
 ``schedule``
 ^^^^^^^^^^^^
@@ -142,25 +226,8 @@ A Cloudwatch Scheduled event for Lambda triggers.
             - ``"rate(5 minutes)"``
             - ``"cron(0 17 ? * MON-FRI *)"``
 
-``rule_name``
-^^^^^^^^^^^^^
-
-    The name of the cloudwatch rule being created.
-
-        | *Type*: string
-        | *Required*: False
-        | *Default*: ``"{app_name}+{schedule}"``
-
-``rule_description``
-^^^^^^^^^^^^^^^^^^^^
-
-    Description of the rule being created.
-
-        | *Type*: string
-        | *Required*: False
-
 ``cloudwatch-logs`` Trigger *Keys*
-===================================
+==================================
 
 A lambda event that triggers off a Cloudwatch log action.
 

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],

--- a/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
+++ b/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
@@ -90,7 +90,7 @@ def create_cloudwatch_event(app_name, env, region, rules):
     elif rule_type == 'event_pattern':
         cloudwatch_client.put_rule(
             Name=rule_name,
-            EventPattern=event_pattern,
+            EventPattern=json.dumps(event_pattern),
             State='ENABLED',
             Description=rule_description)
         LOG.info('Created CloudWatch Rule "%s" with %s: %s', rule_name, rule_type, event_pattern)

--- a/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
+++ b/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
@@ -95,12 +95,15 @@ def create_cloudwatch_event(app_name, env, region, rules):
             Description=rule_description)
         LOG.info('Created CloudWatch Rule "%s" with %s: %s', rule_name, rule_type, event_pattern)
 
-    json_payload = '{}'.format(json.dumps(json_input))
     targets = [{
         "Id": app_name,
         "Arn": lambda_arn,
-        "Input": json_payload,
     }]
+
+    if json_input:
+        json_payload = '{}'.format(json.dumps(json_input))
+        for each_target in targets:
+            each_target['Input'] = json_payload
 
     put_targets_response = cloudwatch_client.put_targets(Rule=rule_name, Targets=targets)
     LOG.debug('CloudWatch PutTargets Response: %s', put_targets_response)

--- a/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
+++ b/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
@@ -70,14 +70,14 @@ def create_cloudwatch_event(app_name, env, region, rules):
     principal = "events.amazonaws.com"
     statement_id = '{}_cloudwatch_{}'.format(app_name, rule_name)
     source_arn = 'arn:aws:events:{}:{}:rule/{}'.format(region, account_id, rule_name)
-    add_lambda_permissions(function=lambda_arn,
+    add_lambda_permissions(
+        function=lambda_arn,
         statement_id=statement_id,
         action='lambda:InvokeFunction',
         principal=principal,
         source_arn=source_arn,
         env=env,
-        region=region
-    )
+        region=region)
 
     # Create CloudWatch rule
     if rule_type == 'schedule':


### PR DESCRIPTION
There have been some significant enhancements to how Lambda Events work, no longer do you just need to use cron schedules. You can actually use Lambda Event patterns to generate triggers of events based on cloudwatch rules!