### PR TITLE
feat: Add github token gate authentication

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -239,7 +239,7 @@ passwords
         | *Default*: ``None``
         | *Example Configuration*:
 
-            .. code-block:: json
+.. code-block:: json
 
             {
                 'credentials': {
@@ -248,6 +248,9 @@ passwords
                             'enabled': False,
                             'oauth_client_id': 'some_id.apps.googleusercontent.com',
                             'sa_credentials_path': '/tmp/google-service-account.json'
+                        },
+                        'github': {
+                            'token': '<GITHUB_TOKEN>'
                         }
                     }
                 }

--- a/src/foremast/utils/gate.py
+++ b/src/foremast/utils/gate.py
@@ -45,8 +45,13 @@ def gate_request(method='GET', uri=None, headers={}, data={}, params={}):
             if 'id_token' not in iap_response:
                 raise GoogleIAPTokenError
 
-        headers['Authorization'] = 'Bearer {}'.format(iap_response['id_token'])
-        LOG.info('Successfully set Google IAP Bearer Token in Request.')
+            headers['Authorization'] = 'Bearer {}'.format(iap_response['id_token'])
+            LOG.info('Successfully set Google IAP Bearer Token in Request.')
+        
+        elif 'github' in GATE_AUTHENTICATION:
+            github_token = GATE_AUTHENTICATION['github']['token']
+            headers['Authorization'] = 'Bearer {}'.format(github_token)
+            LOG.info('Successfully set Github Bearer Token in Request.')
 
     method = method.upper()
     if method == 'GET':

--- a/src/foremast/utils/gate.py
+++ b/src/foremast/utils/gate.py
@@ -47,7 +47,7 @@ def gate_request(method='GET', uri=None, headers={}, data={}, params={}):
 
             headers['Authorization'] = 'Bearer {}'.format(iap_response['id_token'])
             LOG.info('Successfully set Google IAP Bearer Token in Request.')
-        
+
         elif 'github' in GATE_AUTHENTICATION:
             github_token = GATE_AUTHENTICATION['github']['token']
             headers['Authorization'] = 'Bearer {}'.format(github_token)


### PR DESCRIPTION
This PR:
- Adds support for github bearer token authentication against `gate`
- Update documentation to show an example of this feature
- Fix `code-block` [identation issue](https://foremast.readthedocs.io/en/stable/configuration_files/foremast_config.html#gate-authentication-keys) on documentation.