### PR TITLE
Update cloudwatch_event.py to reduce length of statement_id

### DIFF
--- a/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
+++ b/src/foremast/awslambda/cloudwatch_event/cloudwatch_event.py
@@ -68,7 +68,7 @@ def create_cloudwatch_event(app_name, env, region, rules):
     # Add lambda permissions
     account_id = get_env_credential(env=env)['accountId']
     principal = "events.amazonaws.com"
-    statement_id = '{}_cloudwatch_{}'.format(app_name, rule_name)
+    statement_id = 'cloudwatch_{}'.format(rule_name)
     source_arn = 'arn:aws:events:{}:{}:rule/{}'.format(region, account_id, rule_name)
     add_lambda_permissions(
         function=lambda_arn,


### PR DESCRIPTION
According to the boto3 logs, statement_id just needs to be something unique: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.add_permission

When generating statementId, the end result in the current version is something like "foremast-XXXXXXX_cloudwatch_XXXXXXXX_YYYYY" where XXXXXXXX is the app name and YYYYY is the cloudwatch event name (see line 61 for where rule_name is set).

With this code change, you'll eliminate the first XXXXXXXXX. This will reduce the occurrences of the following error for end users while keeping the statementId universally unique:

2019-12-14 23:47:38,953 [DEBUG] foremast.utils.awslambda:add_lambda_permissions:131 - Add permission error: An error occurred (ValidationException) when calling the AddPermission operation: 1 validation error detected: Value 'foremast-XXXXXXXXXX_cloudwatch_XXXXXXXXXXXXX_YYYYY' at 'statementId' failed to satisfy constraint: Member must have length less than or equal to 100

(note, in my case XXXXXX is rather long, but I'd come in under 100 chars if XXXXXXXXX didn't appear twice).