### PR TITLE
Feature/multi pipeline manual templates

### DIFF
--- a/_docs/configuration_files/advanced_usages/manual_pipelines.rst
+++ b/_docs/configuration_files/advanced_usages/manual_pipelines.rst
@@ -93,7 +93,7 @@ Getting a Spinnaker Pipeline's JSON Body
          
          .. code-block:: json
 
-            {
+            [{
                 "schema" : "v2",
                 "locked": {
                   "allowUnlockUi": false,
@@ -108,4 +108,55 @@ Getting a Spinnaker Pipeline's JSON Body
                 }
                 "pipeline": {},
                 "triggers": []
-            }
+            }]
+
+Formatting your pipeline template file
+****************************************
+
+Your pipeline template file should return an array with 1 or more Spinnaker pipeline definitions. 
+Using an array allows Foremast to support the creation of more than one pipeline using
+a single pipeline template file.  The most common usecase for this is creating
+two pipelines that are dependent on eachother, for example one pipeline that triggers when
+another finishes running.  If only one pipeline is desired you should still use an array, but 
+only place one Spinnaker pipeline definition in the array.
+
+*multiple-pipelines-jinja-example.json.j2*
+         
+  .. code-block:: json
+
+    [{
+        "name" : "The first pipeline",
+        "schema" : "v2",
+        "locked": {
+          "allowUnlockUi": false,
+          "ui": true
+        },
+        "protect": false,
+        "metadata": {
+            "name": "{{ template_variables.key }}",
+            "description": "Deploys code to {{ template_variables.region }}",
+            "owner": "{{ template_variables.name }}",
+            "scopes": ["global"]
+        }
+        "pipeline": {},
+        "triggers": []
+    },{
+        "name" : "The second pipeline",
+        "schema" : "v2",
+        "locked": {
+          "allowUnlockUi": false,
+          "ui": true
+        },
+        "protect": false,
+        "metadata": {
+            "name": "{{ template_variables.key }}",
+            "description": "Deploys code to {{ template_variables.region }}",
+            "owner": "{{ template_variables.name }}",
+            "scopes": ["global"]
+        }
+        "pipeline": {},
+        "triggers": []
+    }]
+
+  .. note::   | `template_variables` are shared per file.  Multiple Spinnaker pipelines defined in 
+              | a single file are sharing a common set of variables

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -48,7 +48,8 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
                 # Catch all exceptions (we don't know what errors the jinja2 user code may throw)
                 # Add logging, then re-raise
                 except Exception:
-                    self.log.exception("Exception raised during Jinja 2 template rendering.  Check syntax in templates.")
+                    log_message = "Exception raised during Jinja 2 template rendering.  Check syntax in templates."
+                    self.log.exception(log_message)
                     raise
                 self.log.info("Jinja2 template successfully rendered")
 
@@ -73,9 +74,9 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
             for pipeline_dict in pipelines:
                 pipeline_dict.setdefault('application', self.app_name)
                 pipeline_dict.setdefault('name',
-                                        normalize_pipeline_name(name=file_name.lstrip("templates://")))
+                                         normalize_pipeline_name(name=file_name.lstrip("templates://")))
                 pipeline_dict.setdefault('id', get_pipeline_id(app=pipeline_dict['application'],
-                                                            name=pipeline_dict['name']))
+                                                               name=pipeline_dict['name']))
                 self.post_pipeline(pipeline_dict)
 
         return True


### PR DESCRIPTION
Implements #382 

A single manual pipeline template (both JSON and J2) can now output either:
* A single pipeline object 
`{ application: "my app", ... }`
* An array of pipeline objects 
`[ { application: "my app", ... }, { application: "my app 2", ... } ]` 

The primary use case is to support creation of pipelines that are dependent on each other.  For example, a canary deployment pipeline and a canary cleanup pipeline that triggers on completion of the canary deployment pipeline.  Use cases that require this sort of setup can generally be solved with SPEL but in my experience this is clunky and error prone.





