### PR TITLE
docs: Update faulty lambda-tracing example JSON

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -187,7 +187,7 @@ Currently AWS API supports Active or PassThrough.
 .. code-block:: json
 
    "lambda_tracing": {
-            "TracingConfig": "Active"
+            "Mode": "Active"
         }
 
 


### PR DESCRIPTION
```json
"lambda_tracing": {
    "TracingConfig": "Active"
}
```
The above configuration example results in the following error from the underlying `boto3` lambda client:
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in TracingConfig: "TracingConfig", must be one of: Mode
```
Instead, the client expects the following structure: 
```
"lambda_tracing": {
    "Mode": "Active" | "Passthrough"
}
```
Updating the `application-master-*.json` documentation accordingly.