### PR TITLE
feat: Added support for branch based S3 Deployments

### DIFF
--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -56,6 +56,7 @@ class ForemastRunner:
         self.runway_dir = os.getenv("RUNWAY_DIR")
         self.artifact_path = os.getenv("ARTIFACT_PATH")
         self.artifact_version = os.getenv("ARTIFACT_VERSION")
+        self.artifact_branch = os.getenv("ARTIFACT_BRANCH", "master")
         self.promote_stage = os.getenv("PROMOTE_STAGE", "latest")
         self.provider = os.getenv("PROVIDER", "aws")
 
@@ -167,6 +168,7 @@ class ForemastRunner:
             prop_path=self.json_path,
             artifact_path=self.artifact_path,
             artifact_version=self.artifact_version,
+            artifact_branch=self.artifact_branch,
             primary_region=primary_region)
         s3obj.upload_artifacts()
 
@@ -181,6 +183,7 @@ class ForemastRunner:
             prop_path=self.json_path,
             artifact_path=self.artifact_path,
             artifact_version=self.artifact_version,
+            artifact_branch=self.artifact_branch,
             primary_region=primary_region)
         s3obj.promote_artifacts(promote_stage=self.promote_stage)
 

--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -27,7 +27,8 @@ LOG = logging.getLogger(__name__)
 class S3Deployment:
     """Handle uploading artifacts to S3 and S3 deployment strategies."""
 
-    def __init__(self, app, env, region, prop_path, artifact_path, artifact_version, artifact_branch, primary_region='us-east-1'):
+    def __init__(self, app, env, region, prop_path, 
+                 artifact_path, artifact_version, artifact_branch, primary_region='us-east-1'):
         """S3 deployment object.
 
         Args:

--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 class S3Deployment:
     """Handle uploading artifacts to S3 and S3 deployment strategies."""
 
-    def __init__(self, app, env, region, prop_path, 
+    def __init__(self, app, env, region, prop_path,
                  artifact_path, artifact_version, artifact_branch, primary_region='us-east-1'):
         """S3 deployment object.
 

--- a/tests/s3/test_s3deploy.py
+++ b/tests/s3/test_s3deploy.py
@@ -30,7 +30,7 @@ def test_get_cmd(s3deployment):
     actual_mirror_cmd = s3deployment._get_upload_cmd(mirror=True)
     assert actual_nomirror_cmd == expected_nomirror_cmd
     assert actual_mirror_cmd == expected_mirror_cmd
-    
+
 def test_path_formatter(s3deployment):
     """Tests s3.S3Deployment._path_formatter returns correct path"""
     expected_latest_path = "s3://testapp/LATEST"
@@ -39,4 +39,3 @@ def test_path_formatter(s3deployment):
     actual_mirror_path = s3deployment._path_formatter("MIRROR")
     assert actual_latest_path == expected_latest_path
     assert actual_mirror_path == expected_mirror_path
-

--- a/tests/s3/test_s3deploy.py
+++ b/tests/s3/test_s3deploy.py
@@ -27,7 +27,7 @@ def test_get_cmd(s3deployment):
     expected_nomirror_cmd = "aws s3 sync /artifact s3://testapp/1 --delete --exact-timestamps --profile dev"
     expected_mirror_cmd = "aws s3 sync /artifact s3://testapp/ --delete --exact-timestamps --profile dev"
     actual_nomirror_cmd = s3deployment._get_upload_cmd()
-    actual_mirror_cmd = s3deployment._get_upload_cmd(mirror=True)
+    actual_mirror_cmd = s3deployment._get_upload_cmd(deploy_strategy="mirror")
     assert actual_nomirror_cmd == expected_nomirror_cmd
     assert actual_mirror_cmd == expected_mirror_cmd
 

--- a/tests/s3/test_s3deploy.py
+++ b/tests/s3/test_s3deploy.py
@@ -18,6 +18,7 @@ def s3deployment(mock_get_details, mock_get_props):
                                 region="us-east-1",
                                 prop_path="/",
                                 artifact_path="/artifact",
+                                artifact_branch="master",
                                 artifact_version="1")
     return deployobj
 

--- a/tests/s3/test_s3deploy.py
+++ b/tests/s3/test_s3deploy.py
@@ -26,7 +26,7 @@ def test_get_cmd(s3deployment):
     """Tests s3.S3Deployment._get_upload_cmd returns correct cmd"""
     expected_nomirror_cmd = "aws s3 sync /artifact s3://testapp/1 --delete --exact-timestamps --profile dev"
     expected_mirror_cmd = "aws s3 sync /artifact s3://testapp/ --delete --exact-timestamps --profile dev"
-    actual_nomirror_cmd = s3deployment._get_upload_cmd()
+    actual_nomirror_cmd = s3deployment._get_upload_cmd(deploy_strategy="highlander")
     actual_mirror_cmd = s3deployment._get_upload_cmd(deploy_strategy="mirror")
     assert actual_nomirror_cmd == expected_nomirror_cmd
     assert actual_mirror_cmd == expected_mirror_cmd


### PR DESCRIPTION
- Allows mirroring of git branches to s3 buckets using versioned folders
- refactor: renamed logic from uri to path for simplicity and understanding
- refactor: removed dependency on mirror (bool) to deploy_strategy (str)