### PR TITLE
feat: implement foremast add of lambda qualifiers

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -134,6 +134,26 @@ Environment variables which are passed to the lambda function.
        }
    }
 
+``lambda_qualifier_permission``
+**********************
+
+When using an S3 pipeline to a bucket with multiple lambda functions they don't have any out of the box granted permissions to invoke the function in the instance of e.g. an S3 put event. 
+
+    | *Type*: Object
+    | *Default*: ``{}``
+
+``lambda_qualifier_permission`` *Example*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+   "lambda_qualifier_permission": {
+            "statement-id": "s3-datalake-access", 
+            "principal": "s3.amazonaws.com", 
+            "source-arn": "arn:aws:s3:::bucket"
+        }
+
+
 ``lambda_layers``
 *****************
 

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -10,6 +10,7 @@
         "lambda_environment": {},
         "lambda_layers": [],
         "lambda_memory": "128",
+        "lambda_qualifier_permission": {},
         "lambda_role": null,
         "lambda_tracing": {},
         "lambda_timeout": "30",


### PR DESCRIPTION
When S3 Pipeline is used to manage multiple lambda functions, notifications, etc. No permissions are created to invoke a lambda function. 

This functionality will add the ability for foremast to create the qualifier and thus remove manual devops creations. 