### PR TITLE
feat: First commit of lambda destinations

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -86,6 +86,36 @@ If you exceed a concurrency limit, Lambda starts throttling the offending functi
 
 More info on limits can be found here: https://docs.aws.amazon.com/lambda/latest/dg/limits.html
 
+``lambda_destinations``
+*****************
+
+This feature provides the ability to control what happens when a function is successful or fails e.g. if a specific function fails you may want to invoke another lambda function to perform some error management. In the past you would have to add this bespoke functionality into your code. 
+
+Destinations currently support following:
+* ARN of Lambda Function
+* ARN of SQS Queue
+* ARN of SNS Topic
+* ARN of Amazon EventBridge event bus
+
+You may either an individual destination path OR one for both success and failure. 
+
+More details on lambda destinations can be found here: https://aws.amazon.com/blogs/compute/introducing-aws-lambda-destinations/
+
+    | *Type*: Object
+    | *Default*: ``{}``
+
+``lambda_destinations`` *Example*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+   "lambda_destinations": {
+    "OnSuccess": { "Destination": "arn"},
+    "OnFailure": { "Destination": "arn"}
+    }
+
+
+
 ``lambda_dlq``
 *****************
 

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -60,6 +60,7 @@ class LambdaFunction:
         app = self.settings['app']
         self.lambda_environment = app['lambda_environment']
         self.lambda_layers = app['lambda_layers']
+        self.lambda_destinations = app['lambda_destinations']
         self.lambda_dlq = app['lambda_dlq']
         self.lambda_tracing = app['lambda_tracing']
         self.memory = app['lambda_memory']
@@ -196,6 +197,12 @@ class LambdaFunction:
                 )
             else:
                 self.lambda_client.delete_function_concurrency(FunctionName=self.app_name)
+
+            if self.lambda_destinations:
+                self.lambda_client.put_function_event_invoke_config(
+                    FunctionName=self.app_name,
+                    DestinationConfig=self.lambda_destinations
+                    )
 
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -202,7 +202,7 @@ class LambdaFunction:
                 self.lambda_client.put_function_event_invoke_config(
                     FunctionName=self.app_name,
                     DestinationConfig=self.lambda_destinations
-                    )
+                )
 
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -6,6 +6,7 @@
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",
         "instance_type": "t2.micro",
+        "lambda_destinations": {},
         "lambda_dlq": {},
         "lambda_environment": {},
         "lambda_layers": [],

--- a/tests/lambda/test_aws.py
+++ b/tests/lambda/test_aws.py
@@ -20,6 +20,7 @@ TEST_PROPERTIES = {
         'lambda_layers': None,
         'lambda_dlq': None,
         'lambda_tracing': None,
+        'lambda_destinations': None,
     }
 }
 GENERATED_IAM = {

--- a/tests/lambda/test_event.py
+++ b/tests/lambda/test_event.py
@@ -58,6 +58,7 @@ def get_properties_with_triggers(triggers):
             'lambda_layers': None,
             'lambda_dlq': None,
             'lambda_tracing': None,
+            'lambda_destinations': None,
         },
         "lambda_triggers": triggers
     }


### PR DESCRIPTION
Closes #403 

This simple feature provides the ability for developers to control destinations for success and failure if desired. 

For example: If a lambda function fails you may want to run an exception handler lambda utility that performs clean up.

