### PR TITLE
feat: lambda_subnet_count to limit subnets associated to VPC Enabled Lambda

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -66,7 +66,7 @@ instance profile based on the default string. Specifying a different profile
 name assumes the profile exists.
 
     | *Type*: string
-    | *Default*: ``"${stack}_${app}_profile"``
+    | *Default*: ``"${group}_${app}_profile"``
 
 ``instance_type``
 *****************
@@ -187,7 +187,21 @@ The amount of memory to give a Lambda function
 Override the default generated IAM Role name.
 
     | *Type*: string
-    | *Default*: ``"${stack}_${app}_role"``
+    | *Default*: ``"${group}_${app}_role"``
+
+``lambda_subnet_count``
+***********************
+
+Enables ablity to specify subnet resiliency of lambda functions. By default, uses all subnets of type ``subnet_purpose`` specified.
+
+Each VPC in your AWS account has a Hyperplane ENI limit. The ENI Limit determines how many Hyperplane ENIs you can have in one VPC. The limit applies to Lambda in the same VPC and is set to 250 by default. If you exceed a ENI Limit, Lambda deployment will fail with a Hyperplane ENI Limit error. 
+
+At this time, you will need to submit a limit increase or reduce how many SG:Subnet Tuples you have per function. When you connect a function to a VPC, Lambda creates an elastic network interface for each combination of security group and subnet in your function's VPC configuration.
+
+More info on limits can be found here: https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+
+    | *Type*: int
+    | *Default*: ``<<MAX SUBNET COUNT>>``
 
 ``lambda_timeout``
 ******************

--- a/_docs/configuration_files/pipeline_json/lambda.rest
+++ b/_docs/configuration_files/pipeline_json/lambda.rest
@@ -13,6 +13,14 @@ Lambda function description
     | *Type*: string
     | *Default*: ``"default description"``
 
+``handler``
+***********
+
+The function that Lambda calls to beign execution
+
+    | *Type*: string
+    | *Default*: ``"main"``
+
 ``runtime``
 ***********
 
@@ -34,14 +42,6 @@ Since value is passed directly to the lambda API new runtimes are automatically 
         - ``"dotnetcore2.0"``
         - ``"nodejs4.3-edge"``
         - ``"go1.x"``
-
-``handler``
-***********
-
-The function that Lambda calls to beign execution
-
-    | *Type*: string
-    | *Default*: ``"main"``
 
 ``vpc_enabled``
 ***************

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -68,7 +68,7 @@ class LambdaFunction:
         self.role = app.get('lambda_role') or generated.iam()['lambda_role']
         self.timeout = app['lambda_timeout']
         self.concurrency_limit = app.get('lambda_concurrency_limit')
-        self.subnet_count = self.pipeline['lambda_subnet_count']
+        self.subnet_count = app['lambda_subnet_count']
 
         self.role_arn = get_role_arn(self.role, self.env, self.region)
 

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -56,7 +56,6 @@ class LambdaFunction:
         self.handler = self.pipeline['handler']
         self.vpc_enabled = self.pipeline['vpc_enabled']
 
-
         self.settings = get_properties(prop_path, env=self.env, region=self.region)
         app = self.settings['app']
         self.lambda_environment = app['lambda_environment']

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -16,7 +16,7 @@
         "lambda_role": null,
         "lambda_subnet_count": null,
         "lambda_timeout": "30",
-        "lambda_tracing": {},
+        "lambda_tracing": {}
     },
     "asg": {
         "hc_type": "ELB",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -1,21 +1,22 @@
 {
     "app": {
         "app_description": null,
-        "email": null,
         "archaius_enabled": false,
+        "canary": false,
+        "email": null,
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",
         "instance_type": "t2.micro",
+        "lambda_concurrency_limit": null,
         "lambda_destinations": {},
         "lambda_dlq": {},
         "lambda_environment": {},
         "lambda_layers": [],
         "lambda_memory": "128",
         "lambda_role": null,
-        "lambda_tracing": {},
+        "lambda_subnet_count": null,
         "lambda_timeout": "30",
-        "canary": false,
-        "lambda_concurrency_limit": null
+        "lambda_tracing": {},
     },
     "asg": {
         "hc_type": "ELB",

--- a/tests/lambda/test_aws.py
+++ b/tests/lambda/test_aws.py
@@ -21,6 +21,7 @@ TEST_PROPERTIES = {
         'lambda_dlq': None,
         'lambda_tracing': None,
         'lambda_destinations': None,
+        'lambda_subnet_count': None,
     }
 }
 GENERATED_IAM = {

--- a/tests/lambda/test_event.py
+++ b/tests/lambda/test_event.py
@@ -59,6 +59,7 @@ def get_properties_with_triggers(triggers):
             'lambda_dlq': None,
             'lambda_tracing': None,
             'lambda_destinations': None,
+            'lambda_subnet_count': None,
         },
         "lambda_triggers": triggers
     }


### PR DESCRIPTION
This allows teams to specify how many subnets they want associated to their lambda functions. Due to a limitation of AWS' recent Hyperplane changes, accounts are limited to 250 ENIs. This means if you deploy a Lambda in a VPC with 3 Subnets and a unique SG, each lambda will make 3 ENIs. We burned through the limit rather fast and I am sure other users of foremast may soon do the same.

By doing this, it enables teams to specify how resilient they need lambdas to be, by default and for  backwards compatibility, we default to all subnets. Teams can reduce this to 1 or as many needed.