### PR TITLE
Added support for lambda gateway integration type

### DIFF
--- a/_docs/lambda/lambda_events.rst
+++ b/_docs/lambda/lambda_events.rst
@@ -147,6 +147,21 @@ Sets up an API Gatway event to trigger a lambda function.
         | *Required*: True
         | *Example*: ``"GET"``
 
+``api_type``
+^^^^^^^^^^
+
+    The API Type for the gateway integration.
+
+        | *Type*: string
+        | *Required*: False
+        | *Default*: ``"AWS"``
+        | *Values*:
+
+            - ``"HTTP"``
+            - ``"MOCK"``
+            - ``"HTTP_PROXY"``
+            - ``"AWS_PROXY"``
+
 ``cloudwatch-event`` Event Pattern Trigger *Keys*
 =================================================
 

--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -135,9 +135,9 @@ class AutoScalingPolicy:
                 self.delete_existing_scaling_policy(scaling_policy, server_group)
 
         if self.settings['asg']['scaling_policy']:
-                self.prepare_policy_template('scale_up', server_group)
-                if self.settings['asg']['scaling_policy'].get('scale_down', True):
-                    self.prepare_policy_template('scale_down', server_group)
+            self.prepare_policy_template('scale_up', server_group)
+            if self.settings['asg']['scaling_policy'].get('scale_down', True):
+                self.prepare_policy_template('scale_down', server_group)
         elif self.settings['asg']['custom_scaling_policies']:
             for scaling_policy in self.settings['asg']['custom_scaling_policies']:
                 self.prepare_policy_template('custom', server_group, scaling_policy)

--- a/src/foremast/awslambda/api_gateway_event/api_gateway_event.py
+++ b/src/foremast/awslambda/api_gateway_event/api_gateway_event.py
@@ -87,13 +87,19 @@ class APIGateway:
     def add_lambda_integration(self):
         """Attach lambda found to API."""
         lambda_uri = self.generate_uris()['lambda_uri']
+        api_type = None
+        if 'api_type' in self.trigger_settings:
+            api_type = self.trigger_settings['api_type']
+            self.log.info("Found API Integration Type: %s", api_type)
+        else:
+            api_type = 'AWS'
         self.client.put_integration(
             restApiId=self.api_id,
             resourceId=self.resource_id,
             httpMethod=self.trigger_settings['method'],
             integrationHttpMethod='POST',
             uri=lambda_uri,
-            type='AWS')
+            type=api_type)
         self.add_integration_response()
         self.log.info("Successfully added Lambda intergration to API")
 

--- a/src/foremast/awslambda/awslambdaevent.py
+++ b/src/foremast/awslambda/awslambdaevent.py
@@ -27,6 +27,7 @@ from .sns_event import create_sns_event
 
 LOG = logging.getLogger(__name__)
 
+
 # pylint: disable=too-few-public-methods
 class LambdaEvent:
     """Manipulate Lambda events."""

--- a/src/foremast/utils/kayenta.py
+++ b/src/foremast/utils/kayenta.py
@@ -48,4 +48,4 @@ def get_canary_id(name, application=None):
             return config['id']
 
     raise SpinnakerPipelineCreationFailed(
-        'Could not resolve canary config id for: {0}.  Options are: {2}'.format(name, names))
+        'Could not resolve canary config id for: {0}.  Options are: {1}'.format(name, names))


### PR DESCRIPTION
Issue:
- Foremast was hardcoded to set API gateway integration to "AWS". 
- Developers were unable to set integration type for API Gateways.

Fix:
- Add new setting "api_type" to allow users to set integration type.
- Default to "AWS" if setting not set.