### PR TITLE
Feature/gcp print env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ google-cloud-secret-manager==0.2.0
 google-api-python-client==1.7.11
 google-auth==1.11.2
 google-auth-httplib2==0.0.3
+tabulate==0.8.7

--- a/src/foremast/__main__.py
+++ b/src/foremast/__main__.py
@@ -16,7 +16,7 @@ def add_infra(subparsers):
     """Infrastructure subcommands."""
     infra_parser = subparsers.add_parser('infra', help=runner.prepare_infrastructure.__doc__)
     infra_parser.set_defaults(func=runner.prepare_infrastructure)
-    infra_print_subparser = infra_parser.add_subparsers(title='Print GCP Environments')
+    infra_print_subparser = infra_parser.add_subparsers(title='Infra Subcommands')
     print_env_parser = infra_print_subparser.add_parser("print-environment", help=runner.print_gcp_environments.__doc__)
     print_env_parser.set_defaults(func=runner.print_gcp_environments)
     print_env_parser.add_argument('--print-table-format', default="fancy_grid", required=False,

--- a/src/foremast/__main__.py
+++ b/src/foremast/__main__.py
@@ -14,8 +14,15 @@ LOG = logging.getLogger(__name__)
 
 def add_infra(subparsers):
     """Infrastructure subcommands."""
-    infra_parser = subparsers.add_parser('infra', help=runner.prepare_infrastructure.__doc__)
-    infra_parser.set_defaults(func=runner.prepare_infrastructure)
+    infra_parser = subparsers.add_parser('infra', help=runner.infra_entrypoint.__doc__)
+    infra_parser.set_defaults(func=runner.infra_entrypoint)
+    # 'store_true' action defaults to false, true when flag is added:
+    infra_parser.add_argument('--print-gcp-environments', action='store_true', help="Prints a simple visual output of "
+                                                                                    "GCP Environments visible to "
+                                                                                    "Foremast")
+    infra_parser.add_argument('--print-table-format', default="fancy_grid",
+                              help="Format of output when using --print-gcp-environments.  Common options are grid, "
+                                   "fancy_grid, jira.  See tabulate package docs for full list of options.")
 
 
 def add_pipeline(subparsers):

--- a/src/foremast/__main__.py
+++ b/src/foremast/__main__.py
@@ -14,15 +14,16 @@ LOG = logging.getLogger(__name__)
 
 def add_infra(subparsers):
     """Infrastructure subcommands."""
-    infra_parser = subparsers.add_parser('infra', help=runner.infra_entrypoint.__doc__)
-    infra_parser.set_defaults(func=runner.infra_entrypoint)
-    # 'store_true' action defaults to false, true when flag is added:
-    infra_parser.add_argument('--print-gcp-environments', action='store_true', help="Prints a simple visual output of "
-                                                                                    "GCP Environments visible to "
-                                                                                    "Foremast")
-    infra_parser.add_argument('--print-table-format', default="fancy_grid",
-                              help="Format of output when using --print-gcp-environments.  Common options are grid, "
-                                   "fancy_grid, jira.  See tabulate package docs for full list of options.")
+    infra_parser = subparsers.add_parser('infra', help=runner.prepare_infrastructure.__doc__)
+    infra_parser.set_defaults(func=runner.prepare_infrastructure)
+    infra_print_subparser = infra_parser.add_subparsers(title='Print GCP Environments')
+    print_env_parser = infra_print_subparser.add_parser("print-environment", help=runner.print_gcp_environments.__doc__)
+    print_env_parser.set_defaults(func=runner.print_gcp_environments)
+    print_env_parser.add_argument('--print-table-format', default="fancy_grid", required=False,
+                                  help="Format of output.  Common options are grid, fancy_grid, jira."
+                                       "See tabulate package docs for full list of options.")
+    print_env_parser.add_argument('--print-to-file', default=None, required=False,
+                                  help="File path to output the printed table to instead of displaying on the console")
 
 
 def add_pipeline(subparsers):

--- a/src/foremast/__main__.py
+++ b/src/foremast/__main__.py
@@ -16,14 +16,6 @@ def add_infra(subparsers):
     """Infrastructure subcommands."""
     infra_parser = subparsers.add_parser('infra', help=runner.prepare_infrastructure.__doc__)
     infra_parser.set_defaults(func=runner.prepare_infrastructure)
-    infra_print_subparser = infra_parser.add_subparsers(title='Infra Subcommands')
-    print_env_parser = infra_print_subparser.add_parser("print-environment", help=runner.print_gcp_environments.__doc__)
-    print_env_parser.set_defaults(func=runner.print_gcp_environments)
-    print_env_parser.add_argument('--print-table-format', default="fancy_grid", required=False,
-                                  help="Format of output.  Common options are grid, fancy_grid, jira."
-                                       "See tabulate package docs for full list of options.")
-    print_env_parser.add_argument('--print-to-file', default=None, required=False,
-                                  help="File path to output the printed table to instead of displaying on the console")
 
 
 def add_pipeline(subparsers):
@@ -92,6 +84,25 @@ def add_validate(subparsers):
     validate_gate_parser.set_defaults(func=validate.validate_gate)
 
 
+def add_describe(subparsers):
+    """Describe subcommands"""
+    describe_parser = subparsers.add_parser('describe', help="Shows details of specific Foremast "
+                                                             "resources/configurations")
+    desc_parser_subparsers = describe_parser.add_subparsers(title='Describe Commands', description='Available commands')
+    add_describe_environments(desc_parser_subparsers)
+
+
+def add_describe_environments(describe_subparser):
+    desc_env_parser = describe_subparser.add_parser("environments", help="Shows IAM details for a cloud provider")
+    desc_env_parser.set_defaults(func=runner.describe_environments)
+    desc_env_parser.add_argument('cloud_provider', choices=['aws', 'gcp'], help="Cloud provider to describe")
+    desc_env_parser.add_argument('--print-table-format', default="fancy_grid", required=False,
+                                 help="Format of output.  Common options are grid, fancy_grid, jira."
+                                 "See tabulate package docs for full list of options.")
+    desc_env_parser.add_argument('--print-to-file', default=None, required=False,
+                                 help="File path to output the printed table to instead of displaying on the console")
+
+
 def main(manual_args=None):
     """Foremast, your ship's support."""
     parser = argparse.ArgumentParser(description=main.__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -114,6 +125,7 @@ def main(manual_args=None):
     add_autoscaling(subparsers)
     add_scheduled_actions(subparsers)
     add_validate(subparsers)
+    add_describe(subparsers)
 
     CliArgs = collections.namedtuple('CliArgs', ['parsed', 'extra'])
 

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -276,16 +276,9 @@ class ForemastRunner:
         os.remove(self.raw_path)
 
 
-def infra_entrypoint(args):
-    """Entry point for preparing the infrastructure in a specific env."""
-    if args.parsed.print_gcp_environments:
-        print_gcp_environments(table_format=args.parsed.print_table_format)
-    else:
-        prepare_infrastructure()
-
-
 def prepare_infrastructure():
     """Entry point for preparing the infrastructure in a specific env."""
+
     runner = ForemastRunner()
     runner.write_configs()
 
@@ -351,8 +344,9 @@ def prepare_infrastructure_aws(runner, pipeline_type):
     runner.cleanup()
 
 
-def print_gcp_environments(table_format):
-    """Prints a table of visible Foremast GCP environments"""
+def print_gcp_environments(args):
+    """Prints a simple visual output of GCP Environments visible to Foremast"""
+
     table_header = ["Environment", "Project", "Permitted Groups"]
     env_table = list()
     all_envs = GcpEnvironment.get_environments_from_config()
@@ -366,8 +360,14 @@ def print_gcp_environments(table_format):
             else:
                 groups = "N/A"
             env_table.append([env.name, project["projectId"], groups])
+    output = tabulate(env_table, table_header, tablefmt=args.parsed.print_table_format)
+    if args.parsed.print_to_file:
+        file = open(args.parsed.print_to_file, "w")
+        file.write(output)
+        file.close()
+        LOG.info("Saved printed table to %s", args.parsed.print_to_file)
 
-    print(tabulate(env_table, table_header, tablefmt=table_format))
+    print(output)
 
 
 def prepare_app_pipeline():


### PR DESCRIPTION
In Foremast, much of a GCP environment is defined in GCP itself and not in Foremast's config.  It would be helpful if Foremast could output of how it sees all GCP environments.  This could help identify permissions issues with Foremast's GCP service accounts, help in debugging and documentation.  For feature parity, printing AWS environments is supported but only provides a simple list from the foremast configuration.

Changes:
* Added feature to print a formatted table of GCP and AWS environments

Usage:
`foremast describe environments {gcp,aws}` will produce something like:

```
╒═══════════════╤═════════════════════════╤════════════════════╕
│ Environment   │ Project                 │ Permitted Groups   │
╞═══════════════╪═════════════════════════╪════════════════════╡
│ dev           │ my-project-one          │ N/A                │
├───────────────┼─────────────────────────┼────────────────────┤
│ dev           │ my-project-two          │ group1,group2      │
╘═══════════════╧═════════════════════════╧════════════════════╛
```

You can also change the output format, e.g. if you want to copy/paste into confluence:
`foremast infra print-environment --print-table-format=jira` will produce something like:

```
|| Environment   || Project                 || Permitted Groups   ||
| dev           | my-project-one | N/A                |
| dev           | my-project-two    | group1,group2            |
```

and `--print-to-file=myfile.txt` will output the table into myfile.txt.

Example of AWS output:

```
╒═══════════════╕
│ Environment   │
╞═══════════════╡
│ env1          │
├───────────────┤
│ env2          │
├───────────────┤
│ env3          │
├───────────────┤
│ env4          │
├───────────────┤
│ env5          │
╘═══════════════╛
```
