### PR TITLE
fix: bug stripping too many template path chars

### DIFF
--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -94,7 +94,12 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
         if file_name.startswith("templates://"):
             if TEMPLATES_PATH is None:
                 raise Exception("Cannot use templates:// schema without TEMPLATES_PATH")
-            file_name = file_name.lstrip("templates://")
+            # Using lstrip or strip can sometimes remove additional chars
+            # We know the string starts with "templates://" already, so remove the exact
+            # number of chars to be safe
+            schema_length = len("templates://")
+            file_name = file_name[schema_length::]
+            self.log.debug("Updated pipeline template file path '%s'", file_name)
             pipeline_templates_path = TEMPLATES_PATH.rstrip("/") + "/pipeline"
             lookup = FileLookup(git_short=None, runway_dir=pipeline_templates_path)
         else:


### PR DESCRIPTION
It seems `str.lstrip("templates://")` is sometimes stripping an additional character.  For example `templates://pipline_stage.json` is being stripped to `ipline_stage.json` and causing pipeline failures.  

Not entirely sure why, but we already know the file path starts with `templates://` at this point in the code so the easy fix is to remove it using Python's substring syntax instead.

