### PR TITLE
Feature/gcp svc account iam policies

### DIFF
--- a/_docs/configuration_files/advanced_usages/GCP Service Account IAM Policies.rst
+++ b/_docs/configuration_files/advanced_usages/GCP Service Account IAM Policies.rst
@@ -1,0 +1,107 @@
+.. _gcp_svc_account_iam_policies
+
+####################################
+GCP Service Account IAM Policies
+####################################
+
+This section shows how to apply a default IAM Policy for a service account during the Foremast infra step and Google Cloud Platform.
+
+In GCP a service account has its own IAM Policy.  *This policy is not used to grant the service account access to other resources.*  Instead the
+policy is used to determine what users or service accounts can access the service account the IAM Policy is assigned to.  This is rarely necessary
+and by default a service account's IAM policy is empty.  One use-case for updating this a service account's policy is
+`GKE Workload Identity <https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity>`_.
+
+.. warning::
+  Foremast uses a Jinja template to update the service account's IAM policy.  Any existing bindings in the policy will be overwritten, including any manual
+  changes made outside of Foremast.
+
+Create the Jinja Template file
+***********************************
+
+Create a Jinja template at your Foremast Templates path: `infrastructure/iam/gcp-service-account.json.j2` which outputs an array of GCP role bindings.
+Several examples are available below.
+
+Foremast will react differently depending on the output of the rendered Jinja template:
+
+1. If only whitespace is output Foremast will not update the service account's IAM Policy.  This allows the template to only be used for certain pipeline types.
+2. If an array of bindings is output, Foremast will update the service accounts IAM Policy bindings using the outputted array of bindings.
+
+Jinja Template Variables
+***********************************
+
+The following arguments are given to the Jinja template:
+
+``app``
+=================================================
+
+  Name of the app being deployed
+
+      | *Type*: string
+      | *Example*: ``myapp``, ``otherapp``
+
+``group``
+=================================================
+
+  Group of the app being deployed
+
+      | *Type*: string
+      | *Example*: ``dogfood``, ``team5``
+
+``env``
+=================================================
+
+  Environment name the service account belongs too
+
+      | *Type*: string
+      | *Example*: ``stage``, ``prod``
+
+``pipeline_type``
+=================================================
+
+  The type of pipeline being deployed
+
+      | *Type*: string
+      | *Example*: ``cloudfunction``, ``manual``
+
+Example: Simple json example
+*************************************
+
+.. code-block:: json
+
+    [
+       {
+          "members": [
+             "serviceAccount:my-project.svc.id.goog[coolgroup/coolapp]"
+          ],
+          "role": "roles/iam.workloadIdentityUser"
+       }
+    ]
+
+Example: Conditional based on pipeline type
+*********************************************
+
+If you only want to update the policy for service accounts in some pipeline types, you can use Jinja if statements to only
+output json for certain pipeline types.  If no json is output (i.e. only whitespace) from the template Foremast will not
+overwrite the service accounts IAM policy.  This allows you to conditionally use this feature based on inputs.
+
+.. code-block:: json
+
+    {% if pipeline_type == 'manual' %}
+    [
+       {
+          "members": [
+             "serviceAccount:my-project.svc.id.goog[coolgroup/coolapp]"
+          ],
+          "role": "roles/iam.workloadIdentityUser"
+       }
+    ]
+    {% endif %}
+
+Troubleshooting Service Account IAM Policies
+*********************************************
+
+Currently the Google Cloud Console does not show service accounts IAM polices.  If you need to verify a policies contents you can use the following command:
+
+.. code-block:: bash
+
+  gcloud iam service-accounts get-iam-policy 'my-svc-account@my-project.iam.gserviceaccount.com'

--- a/_docs/configuration_files/advanced_usages/index.rst
+++ b/_docs/configuration_files/advanced_usages/index.rst
@@ -101,3 +101,11 @@ Foremast Provider Tags
       :maxdepth: 2
 
       foremast_tags
+
+GCP Service Account IAM Policies
+*********************************
+
+    .. toctree::
+      :maxdepth: 2
+
+      gcp_svc_account_iam_policies

--- a/src/foremast/gcp_iam/create_iam_resources.py
+++ b/src/foremast/gcp_iam/create_iam_resources.py
@@ -1,13 +1,12 @@
 from googleapiclient.errors import HttpError
 
-from ..utils import get_template
+from ..utils import get_template_object
 from ..exceptions import ForemastError
 from ..utils.gcp_environment import GcpEnvironment
 from . import get_policy, set_policy, modify_policy_remove_member, modify_policy_add_binding
 from tryagain import retries
 import googleapiclient.discovery
 import json
-
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -134,27 +133,26 @@ class GcpIamResourceClient:
     def _update_policy_for_service_account(self, resource_name):
         """Updates the IAM policy attached to the given service account
         Args:
-            resource_name (str): The service account's full resource name (e.g. projects/my-project/serviceAccounts/myaccount@gke-iam.com)
+            resource_name (str): The service account's full resource name (e.g. projects/../serviceAccounts/..)
         Returns:
             None
         """
-        service_account_api = googleapiclient.discovery.build(
-            'iam', 'v1', credentials=self._credentials, cache_discovery=False).projects().serviceAccounts()
-        iam_policy = service_account_api.getIamPolicy(resource=resource_name).execute()
-        # gcp-service-account.json.j2
-        rendered_bindings = get_template('infrastructure/iam/gcp-service-account.json.j2', **self._get_jinja_args())
+        template = get_template_object('infrastructure/iam/gcp-service-account.json.j2')
+        rendered_template = template.render(**self._get_jinja_args())
         # If the rendered template is just whitespace, skip the step
-        if rendered_bindings.isspace():
+        if not rendered_template or rendered_template.isspace():
             LOG.debug("Skipping IAM Policy update for service account '%s' (this is not the same as updating IAM "
                       "bindings on projects)", resource_name)
             return
-        # Update svc account's IAM Policy
-        bindings = json.loads(rendered_bindings)
-        iam_policy["bindings"] = bindings
+        # Get/update svc account's IAM Policy
+        service_account_api = googleapiclient.discovery.build(
+            'iam', 'v1', credentials=self._credentials, cache_discovery=False).projects().serviceAccounts()
+        iam_policy = service_account_api.getIamPolicy(resource=resource_name).execute()
+        iam_policy["bindings"] = json.loads(rendered_template)
         body_payload = {
             "policy": iam_policy
         }
-        LOG.info("Updating svc account '%s' IAM policy bindings: '%s'", resource_name, rendered_bindings)
+        LOG.info("Updating svc account '%s' IAM policy bindings: '%s'", resource_name, rendered_template)
         service_account_api.setIamPolicy(resource=resource_name, body=body_payload).execute()
 
     def _get_jinja_args(self):


### PR DESCRIPTION
Adds an optional feature to update a service account's IAM policy via a Jinja template.  The main use case is for [GKE workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), where some pipelines need to be linked to a service account in a Kubernetes cluster, but as this may be helpful in other areas Foremast implements this in a generic way that can be used by other pipelines if needed.

As a note, "updating a service account's IAM policy" means updating the IAM policy attached to a service account, which determines which other users/service accounts can access/use the service account.  Updating this IAM policy will not give the service account permissions elsewhere, a project IAM policy is the correct place for that.

This PR is the equivalent of this command in gcloud:

```
gcloud iam service-accounts add-iam-policy-binding \
  --role roles/iam.workloadIdentityUser \
  --member "serviceAccount:project-id.svc.id.goog[default/default]" \
  gsa-name@project-id.iam.gserviceaccount.com
```

