### PR TITLE
fix: Missing repo argument for GCP Svc Account IAM policy

### DIFF
--- a/_docs/configuration_files/advanced_usages/GCP Service Account IAM Policies.rst
+++ b/_docs/configuration_files/advanced_usages/GCP Service Account IAM Policies.rst
@@ -37,6 +37,14 @@ The following arguments are given to the Jinja template:
   Name of the app being deployed
 
       | *Type*: string
+      | *Example*: ``myappmygroup``, ``otherappothergroup``
+
+``repo``
+=================================================
+
+  Repo name of the app being deployed
+
+      | *Type*: string
       | *Example*: ``myapp``, ``otherapp``
 
 ``group``

--- a/src/foremast/gcp_iam/create_iam_resources.py
+++ b/src/foremast/gcp_iam/create_iam_resources.py
@@ -14,13 +14,14 @@ LOG = logging.getLogger(__name__)
 
 class GcpIamResourceClient:
 
-    def __init__(self, env, app_name, group_name, configs):
+    def __init__(self, env, app_name, group_name, repo_name, configs):
         self._env = env
         self._credentials = env.get_credentials()
         self._configs = configs
         self._pipeline_type = configs["pipeline"]["type"]
         self._app_name = app_name
         self._group_name = group_name
+        self._repo_name = repo_name
         self._services = configs["pipeline"].get('services', dict())
 
     def create_iam_resources(self):
@@ -159,6 +160,7 @@ class GcpIamResourceClient:
         return {
             'app': self._app_name,
             'group': self._group_name,
+            'repo': self._repo_name,
             'pipeline_type': self._pipeline_type,
             'env': self._env.name
         }

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -144,7 +144,8 @@ class ForemastRunner:
         """Create GCP IAM resources."""
         utils.banner("Creating GCP IAM")
         env = self.get_current_gcp_env()
-        gcp_iam_client = GcpIamResourceClient(env=env, app_name=self.app, group_name=self.group, configs=self.configs)
+        gcp_iam_client = GcpIamResourceClient(env=env, app_name=self.app, group_name=self.group,
+                                              repo_name=self.repo, configs=self.configs)
         gcp_iam_client.create_iam_resources()
 
     def create_archaius(self):


### PR DESCRIPTION
GCP Service Account IAM Policy Jinja template had app, group and env passed in.  Unfortunately I mistook app for the shorthand project/repo name.  This PR adds the repo name as well.