### PR TITLE
feat: Added support to timeout approval stages after specified time

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -36,6 +36,17 @@ Describes the application.
     | *Type*: string
     | *Default*: ``null``
 
+``approval_timeout``
+*******************
+
+Enable the ability to override Spinnaker's default Stage Timeout (typically 72-hours) with a custom timeout specified in milliseconds.
+This is helpful to maintain cleaner pipelines, and fail pipelines not ready for the next environment.
+For example, ``2 hours`` is represented as ``7200000``.
+
+    | *Type*: int
+    | *Format*: ms
+    | *Default*: ``null``
+
 .. _archaius_enabled:
 
 ``archaius_enabled``

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -1,6 +1,7 @@
 {
     "app": {
         "app_description": null,
+        "approval_timeout": null,
         "archaius_enabled": false,
         "canary": false,
         "email": null,

--- a/src/foremast/templates/pipeline/stage-judgement-nonprod.json.j2
+++ b/src/foremast/templates/pipeline/stage-judgement-nonprod.json.j2
@@ -7,6 +7,9 @@
       "notifications": [],
       "judgmentInputs": [],
       "failPipeline": false,
+      {% if data.app.approval_timeout %}
+        "stageTimeoutMs": {{ data.app.approval_timeout }},
+      {% endif %}
       "instructions": "I confirm that I'm ready for this application to be promoted to <strong>{{ data.app.environment }}</strong>.",
       "comments": ""
     }

--- a/src/foremast/templates/pipeline/stage-judgement-promote-s3-nonprod.json.j2
+++ b/src/foremast/templates/pipeline/stage-judgement-promote-s3-nonprod.json.j2
@@ -7,6 +7,9 @@
       "notifications": [],
       "judgmentInputs": [],
       "failPipeline": false,
+      {% if data.app.approval_timeout %}
+        "stageTimeoutMs": {{ data.app.approval_timeout }},
+      {% endif %}
       "instructions": "I confirm that I'm ready for this S3 content to be promoted to <strong>{{ data.app.environment }} LATEST</strong>.",
       "comments": "application: ${ trigger.properties.APP_NAME }"
     }

--- a/src/foremast/templates/pipeline/stage-judgement-promote-s3-prod.json.j2
+++ b/src/foremast/templates/pipeline/stage-judgement-promote-s3-prod.json.j2
@@ -7,6 +7,9 @@
       "notifications": [],
       "judgmentInputs": [],
       "failPipeline": false,
+      {% if data.app.approval_timeout %}
+        "stageTimeoutMs": {{ data.app.approval_timeout }},
+      {% endif %}
       "instructions": "By approving this S3 content promotion to <strong>{{ data.app.environment }} LATEST</strong>, I certify that:\n<ul>\n<li>I am authorized by Gogo to perform this change</li>\n<li> To the best of my knowledge and ability, this version of the software is fit for purpose</li>\n<li>I did not develop any aspects of the code or configuration that will be promoted with this approval</li>\n</ul>",
       "comments": "application: ${ trigger.properties.APP_NAME }"
     }


### PR DESCRIPTION
Today, pipeline stages timeout after 72 hours. This is done to maintain a clear queue and also performance to prevent stale pipelines. Most pipelines get hung up on approval stages, and as a result sometimes clutter a deployment view.

This feature enables the ability to maintain cleaner pipelines and fail faster than default 72 hour timeout by specifying an approval stage timeout in milliseconds (based on API).