### PR TITLE
fix: better error message when cloud function event resource has duplicate project id

### DIFF
--- a/src/foremast/cloudfunction/cloud_functions_client.py
+++ b/src/foremast/cloudfunction/cloud_functions_client.py
@@ -336,6 +336,11 @@ class CloudFunctionsClient:
 
         GCP Docs: https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#EventTrigger"""
 
+        if partial_path.startswith("projects"):
+            raise CloudFunctionDeployError("Path '{}' contains a hardcoded project identifier. ".format(partial_path) +
+                                           "Foremast adds this automatically based on the target deployment project. " +
+                                           "Path should start at the event type (e.g. databases, bucket, etc).")
+
         return "projects/{}/{}".format(self._project_id, partial_path.lstrip('/'))
 
     @staticmethod


### PR DESCRIPTION
Cloud function triggers should be specified without the project id:
```
"cloudfunction_event_trigger": {
      "resource": "buckets/my-great-bucket",
      "event_type": "google.storage.object.archive"
    },
```

Foremast then adds the project id automatically based on the project it is deploying to.  If a developer accidentally puts the project Id in their pipeline files, this produces something like: `projects/myproject/projects/myproject/buckets/my-great-bucket` leading to an error from the Google API. 

The Google API error is not very clear, so this PR adds a more clear error message from Foremast.