### PR TITLE
feat: Pipeline notification support for all providers and options

### DIFF
--- a/_docs/configuration_files/pipeline_json/index.rst
+++ b/_docs/configuration_files/pipeline_json/index.rst
@@ -56,6 +56,7 @@ Link to the applications documentation. This is not used directly in the pipelin
     | *Default*: ``null``
 
 .. include:: notifications.rest
+.. include:: pipeline_notifications.rest
 
 ``promote_restrict``
 ~~~~~~~~~~~~~~~~~~~~

--- a/_docs/configuration_files/pipeline_json/notifications.rest
+++ b/_docs/configuration_files/pipeline_json/notifications.rest
@@ -1,6 +1,8 @@
 ``notifications`` Block
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning:: ``notifications`` is deprecated, see ``"pipeline_notifications"`` instead
+
 Where to send pipeline failure notifications
 
 ``email``

--- a/_docs/configuration_files/pipeline_json/pipeline_notifications.rest
+++ b/_docs/configuration_files/pipeline_json/pipeline_notifications.rest
@@ -1,0 +1,123 @@
+``pipeline_notifications`` Array
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. info:: ``pipeline_notifications`` replaces ``notifications`, which is now deprecated.
+
+Where to send pipeline notifications.  Notifications can be sent on several events including pipelines starting, completing and failing.
+Any supported notification option in Spinnaker can be defined, including Slack, Microsoft Teams, Bearychat, PubSub, Google Chat and Email.
+
+``pipeline_notifications``
+**************************
+
+Array of notification definitions
+
+    | *Type*: array
+    | *Default*: ``[]``
+
+    | *Example Microsoft Teams*:
+
+    .. code-block:: json
+        [
+            {
+              "level": "pipeline",
+              "type": "microsoftteams",
+              "address": "https://outlook.office.com/webhook/my-webhook",
+              "when": [
+                "pipeline.starting",
+                "pipeline.complete",
+                "pipeline.failed"
+              ]
+            }
+        ]
+
+    | *Example Slack:*
+
+    .. code-block:: json
+        [
+            {
+              "level": "pipeline",
+              "type": "slack",
+              "when": [
+                "pipeline.starting",
+                "pipeline.complete",
+                "pipeline.failed"
+              ],
+              "address": "https://hooks.slack.com/services/my-webhook"
+            }
+        ]
+
+    | *Example Email*:
+
+    .. code-block:: json
+
+        [
+            {
+              "level": "pipeline",
+              "type": "email",
+              "address": "jane.doe@who.com",
+              "cc": "jon.doe@optional.com",
+              "when": [
+                "pipeline.failed",
+                "pipeline.complete",
+                "pipeline.starting"
+              ]
+            }
+        ]
+
+    | *Example Google Cloud Pub/Sub*:
+
+    .. code-block:: json
+
+        [
+            {
+              "level": "pipeline",
+              "type": "pubsub",
+              "publisherName": "my-publisher",
+              "when": [
+                 "pipeline.starting",
+                 "pipeline.complete",
+                 "pipeline.failed"
+              ]
+            }
+        ]
+
+    | *Example Google Chat:*
+
+    .. code-block:: json
+
+        [
+            {
+              "level": "pipeline",
+              "type": "googlechat",
+              "address": "https://chat.google.com/v1/spaces/my-google-chat-space",
+              "when": [
+                "pipeline.starting",
+                "pipeline.complete",
+                "pipeline.failed"
+              ]
+            }
+        ]
+
+    | *Example custom messages:*
+
+    Some notification types support custom messages, which can be defined using the ``messages`` field:
+
+    .. code-block:: json
+
+        [
+            {
+                /* First define your notification, e.g. slack or teams */
+                /* ... */
+                "message": {
+                  "pipeline.complete": {
+                    "text": "A pipeline finished, wow!"
+                  },
+                  "pipeline.failed": {
+                    "text": "A pipeline has failed :("
+                  },
+                  "pipeline.starting": {
+                    "text": "A pipeline started!"
+                  }
+                }
+            }
+        ]

--- a/src/foremast/templates/configs/pipeline.json.j2
+++ b/src/foremast/templates/configs/pipeline.json.j2
@@ -6,6 +6,7 @@
         "email": "",
         "slack": ""
     },
+    "pipeline_notifications": [],
     "promote_restrict": "none",
     "base": "tomcat8",
     "env": ["stage", "prod"],

--- a/src/foremast/templates/pipeline/pipeline_notifications.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_notifications.json.j2
@@ -1,0 +1,27 @@
+[
+{#- v1: data.app.slack and data.app.email are legacy options, supported only for backwards compatibility #}
+{%- if data.app.slack or data.app.email %}
+    {
+      "level": "pipeline",
+      "when": [
+        "pipeline.failed"
+      ],
+      "type": "slack",
+      "address": "{{ data.app.slack }}"
+    },
+    {
+      "level": "pipeline",
+      "when": [
+        "pipeline.failed"
+      ],
+      "type": "email",
+      "address": "{{ data.app.email }}"
+    }
+{%- elif data.app.pipeline.pipeline_notifications %}
+{#- v2 pipeline.pipeline_notification configuration block: #}
+    {%- for notification in data.app.pipeline.pipeline_notifications %}
+    {{ notification | tojson }}
+    {% if not loop.last %},{% endif %}
+    {%- endfor %}
+{%- endif %}
+]

--- a/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
@@ -9,24 +9,7 @@
   ],
   "limitConcurrent": false,
   "parallel": true,
-  "notifications": [
-    {
-      "level": "pipeline",
-      "when": [
-        "pipeline.failed"
-      ],
-      "type": "slack",
-      "address": "{{ data.app.slack }}"
-    },
-    {
-      "level": "pipeline",
-      "when": [
-        "pipeline.failed"
-      ],
-      "type": "email",
-      "address": "{{ data.app.email }}"
-    }
-  ],
+  "notifications": {% include "pipeline/pipeline_notifications.json.j2" %},
   "stages": [
     {% if data.app.deploy_type not in ["lambda", "s3", "datapipeline", "cloudfunction"] %}
       {% include "pipeline/stage-bake.json.j2" %}


### PR DESCRIPTION
Foremast supports Spinnaker pipeline failure notifications for Slack and Email via the `notifications` block in `pipeline.json`.  

Today Spinnaker has a long list of features not supported by Foremast including Microsoft Teams, Google Chat, Pub/Sub, custom messages and triggering based on pipelines starting, failing and completing.  The new alpha features for Spinnaker Plugins also allows custom notification options to be defined ([example](https://github.com/spinnaker-plugin-examples/notificationPlugin)).  This PR adds support for any notification option.

**Deprecation of notifications block**

To achieve support for any notification option a new syntax was needed which mirrors the Spinnaker syntax.  This new option can be defined in `pipeline.json` using the `pipeline_notifications` block, which deprecates the current `notifications` block.  To avoid breaking existing pipelines and custom templates `notifications` block still functions without any changes, but is deprecated in the documentation and should not be given any new features.

See doc changes in this PR for examples on new notification configuration.