### PR TITLE
Feature/manual templates generate pipeline

### DIFF
--- a/src/foremast/pipeline/jinja_functions.py
+++ b/src/foremast/pipeline/jinja_functions.py
@@ -16,7 +16,7 @@
 """Functions and variables that can be exposed to Jinja2 templates"""
 
 from ..utils.kayenta import get_canary_id
-from ..utils.pipelines import get_pipeline_id
+from ..utils.pipelines import get_pipeline_id, generate_predictable_pipeline_id
 
 
 def get_jinja_functions():
@@ -25,6 +25,7 @@ def get_jinja_functions():
     functions[get_canary_id.__name__] = get_canary_id
     functions[get_pipeline_id.__name__] = get_pipeline_id
     functions[raise_exception.__name__] = raise_exception
+    functions[generate_predictable_pipeline_id.__name__] = generate_predictable_pipeline_id
 
     return functions
 

--- a/src/foremast/utils/pipelines.py
+++ b/src/foremast/utils/pipelines.py
@@ -85,20 +85,18 @@ def get_all_pipelines(app=''):
     return pipelines
 
 
-def get_pipeline_id(app='', name='', default=None):
+def get_pipeline_id(app='', name=''):
     """Get the ID for Pipeline _name_.
 
     Args:
         app (str): Name of Spinnaker Application to search.
         name (str): Name of Pipeline to get ID for.
-        default (str): Default value to return if no pipeline is found.  Default is None.
 
     Returns:
         str: ID of specified Pipeline.
-        None: Pipeline or Spinnaker Appliation not found.
-
+        None: Pipeline or Spinnaker Application not found.
     """
-    return_id = default
+    return_id = None
 
     pipelines = get_all_pipelines(app=app)
 
@@ -122,14 +120,15 @@ def normalize_pipeline_name(name=''):
 
 
 def generate_predictable_pipeline_id(application_name, pipeline_name):
-    """Create a predictable pipeline ID (GUID) using an application name and pipeline name.
-    It will always produce the same GUID when given the same arguments
-     Args:
+    """Create a predictable pipeline ID (UUID) using an application name and pipeline name.
+    It will always produce the same UUID when given the same arguments
+
+    Args:
         application_name (str): Name of Spinnaker Application
         pipeline_name (str): Name of the pipeline
 
     Returns:
-        UUID: GUID/UUID generated using the seed arguments
+        UUID: UUID generated using the seed arguments
     """
     seed = application_name + pipeline_name
     pipeline_uuid = uuid.uuid5(_foremast_uuid_namespace, seed)

--- a/tests/pipeline/test_generate_predictable_pipeline_id.py
+++ b/tests/pipeline/test_generate_predictable_pipeline_id.py
@@ -1,0 +1,25 @@
+#   Foremast - Pipeline Tooling
+#
+#   Copyright 2020 Redbox Automated Retail, LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Test generate_predictable_pipeline_id functionality"""
+from foremast.utils.pipelines import generate_predictable_pipeline_id
+
+def test_generate_predictable_pipeline_id():
+    """Tests that generate_predictable_pipeline_id creates a matching UUID with identical seed inputs"""
+    app_name = "testspinnakerapplication"
+    pipeline_name = "testspinnakerpipeline"
+    uuid_1 = generate_predictable_pipeline_id(app_name, pipeline_name)
+    uuid_2 = generate_predictable_pipeline_id(app_name, pipeline_name)
+    assert uuid_1 == uuid_2


### PR DESCRIPTION
**Changes:**
* Adds Jinja function for manual templates `generate_predictable_pipeline_id` which will create reproducible/predictable Spinnaker pipeline Ids for an application and pipeline name.  It must be explicitly called in a Foremast manual template, so this is backwards compatible and opt-in only.

**Summary:**

Ran into an interesting chicken-and-egg scenario with the existing Jinja function `get_pipeline_id`, which resolves a pipeline Id for a given app/pipeline name.  The use case of this function is to reference Pipeline A from Pipeline B, allowing things like “Run Pipeline B when Pipeline A fails/completes”.  Problem is, when creating a pipeline for the first time `get_pipeline_id` returns None, leading to bugs like Pipeline B never triggering as it doesn't have the Pipeline A Id.

To solve this I’ve introduce the above function `generate_predictable_pipeline_id` which can be used when `get_pipeline_id` fails, like so:

```jinja2
{# Get Pipeline ID if exists #}
{%- set trigger_pipeline_id = get_pipeline_id(app_name, pipeline_name) %}
{%- if not trigger_pipeline_id %}
{# Pipeline does not exist, generate ID #}
{%- set trigger_pipeline_id = generate_predictable_pipeline_id(app_name, pipeline_name) %}
{%- endif %}
{# … later set the Id to the variable: #}
{
  "id": "{{ trigger_pipeline_id }}"
}
```

In other words, the first time Foremast generates this pipeline you can force a certain pipeline ID.  The second+ times you can use an existing Id retrieved from the Spinnaker APIs.