### PR TITLE
feat: Manual templates now support default stage templates

### DIFF
--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -97,7 +97,7 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
             # Using lstrip or strip can sometimes remove additional chars
             # We know the string starts with "templates://" already, so remove the exact
             # number of chars to be safe
-            schema_length = len("templatees://")
+            schema_length = len("templates://")
             file_name = file_name[schema_length::]
             self.log.debug("Updated pipeline template file path '%s'", file_name)
             pipeline_templates_path = TEMPLATES_PATH.rstrip("/") + "/pipeline"

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -19,7 +19,7 @@ import jinja2
 
 
 from ..consts import TEMPLATES_PATH
-from ..utils import get_pipeline_id, normalize_pipeline_name
+from ..utils import get_pipeline_id, normalize_pipeline_name, get_jinja_environment
 from ..utils.lookups import FileLookup
 from .create_pipeline import SpinnakerPipeline
 from .jinja_functions import get_jinja_functions, get_jinja_variables
@@ -97,7 +97,7 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
             # Using lstrip or strip can sometimes remove additional chars
             # We know the string starts with "templates://" already, so remove the exact
             # number of chars to be safe
-            schema_length = len("templates://")
+            schema_length = len("templatees://")
             file_name = file_name[schema_length::]
             self.log.debug("Updated pipeline template file path '%s'", file_name)
             pipeline_templates_path = TEMPLATES_PATH.rstrip("/") + "/pipeline"
@@ -118,18 +118,15 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
         Returns:
             str: pipeline json after Jinja is rendered"""
 
-        try:
-            if TEMPLATES_PATH:
-                loader = jinja2.FileSystemLoader(TEMPLATES_PATH)
-            else:
-                loader = jinja2.BaseLoader()
+        jinja_env = get_jinja_environment()
 
-            jinja_template = jinja2.Environment(loader=loader).from_string(json_string)
+        try:
+            jinja_template = jinja_env.from_string(json_string)
             # Get any pipeline args defined in pipeline.json, default to empty dict if none defined
             pipeline_args = dict()
         except jinja2.TemplateNotFound:
             # Log paths searched for debugging, then re-raise
-            message = 'Jinja2 TemplateNotFound exception in paths {paths}'.format(paths=loader.searchpath)
+            message = 'Jinja2 TemplateNotFound exception in paths {paths}'.format(paths=jinja_env.loader.searchpath)
             self.log.error(message)
             raise
 

--- a/src/foremast/pipeline/jinja_functions.py
+++ b/src/foremast/pipeline/jinja_functions.py
@@ -32,10 +32,32 @@ def get_jinja_functions():
 def get_jinja_variables(pipeline):
     """Gets a dictionary of variables from a SpinnakerPipeline that can be exposed to Jinja templates"""
     variables = dict()
+    # Deprecated variables: Use the app block instead
     variables["trigger_job"] = pipeline.trigger_job
     variables["group_name"] = pipeline.group_name
     variables["app_name"] = pipeline.app_name
     variables["repo_name"] = pipeline.repo_name
+    # Deprecated end
+
+    email = pipeline.settings['pipeline']['notifications']['email']
+    slack = pipeline.settings['pipeline']['notifications']['slack']
+    deploy_type = pipeline.settings['pipeline']['type']
+
+    # Replaces top level variables above which are deprecated
+    # app block matches non-manual pipeline types like ec2, lambda, etc for consistency
+    variables["data"] = {
+        'app': {
+            'appname': pipeline.app_name,
+            'group_name': pipeline.group_name,
+            'repo_name': pipeline.repo_name,
+            'deploy_type': deploy_type,
+            'environment': 'packaging',
+            'triggerjob': pipeline.trigger_job,
+            'email': email,
+            'slack': slack,
+            'pipeline': pipeline.settings['pipeline']
+        }
+    }
 
     return variables
 

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -29,6 +29,25 @@ HERE = pathlib.Path(__file__).parent.absolute()
 LOCAL_TEMPLATES = HERE.joinpath('../templates/').resolve()
 
 
+def get_jinja_environment():
+    """Gets the Foremast Jinja environment used for rendering templates
+    Returns:
+        jinja2.Environment
+    """
+    jinja_template_paths_obj = []
+
+    if TEMPLATES_PATH:
+        external_templates = pathlib.Path(TEMPLATES_PATH).expanduser().resolve()
+        assert os.path.isdir(external_templates), 'External template path "{0}" not found'.format(external_templates)
+        jinja_template_paths_obj.append(external_templates)
+
+    jinja_template_paths_obj.append(LOCAL_TEMPLATES)
+    jinja_template_paths = [str(path) for path in jinja_template_paths_obj]
+
+    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_template_paths))
+    return jinjaenv
+
+
 def get_template_object(template_file=''):
     """Retrieve template.
 
@@ -44,17 +63,7 @@ def get_template_object(template_file=''):
             is not available.
 
     """
-    jinja_template_paths_obj = []
-
-    if TEMPLATES_PATH:
-        external_templates = pathlib.Path(TEMPLATES_PATH).expanduser().resolve()
-        assert os.path.isdir(external_templates), 'External template path "{0}" not found'.format(external_templates)
-        jinja_template_paths_obj.append(external_templates)
-
-    jinja_template_paths_obj.append(LOCAL_TEMPLATES)
-    jinja_template_paths = [str(path) for path in jinja_template_paths_obj]
-
-    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_template_paths))
+    jinjaenv = get_jinja_environment()
 
     try:
         template = jinjaenv.get_template(template_file)


### PR DESCRIPTION
This PR allows manual templates to reference Foremast's default Jinja templates and variables used in other pipeline types.

Changes:

* Manual templates now use the same Jinja2 Environment as all other templates
* Manual templates now have access to Jinja2 variables exposed to other templates (e.g. `data.app.pipeline`, `data.app.appname`, etc)
* Existing manual template variables marked as deprecated: `trigger_job`, `group_name`, `app_name`, `repo_name`.  These are now passed in consistently with non-manual templates.  Leaving them in for now for backwards compatibility.

Example:

In a manual template I can now use Foremast's pipeline notification features by doing something like:
```jinja2
{
        "notifications": {% include "pipeline/pipeline_notifications.json.j2" %},
}
```

------------

I noticed the code to pass in variables to JInja templates during pipeline templating is almost identical and in 4-5 places (ec2, manual, lambda, etc.).  That should be consolidated, this is a good first step, but the rest should be a new PR as it will need more testing.