### PR TITLE
fix: AWS IAM put role policy no longer fails silently

### DIFF
--- a/src/foremast/iam/create_iam.py
+++ b/src/foremast/iam/create_iam.py
@@ -71,6 +71,7 @@ def create_iam_resources(env='dev', app='', **_):
             client,
             action='put_role_policy',
             log_format='Added IAM Policy: %(PolicyName)s',
+            raise_errors=True,
             RoleName=details.role,
             PolicyName=details.policy,
             PolicyDocument=iam_policy)

--- a/src/foremast/iam/resource_action.py
+++ b/src/foremast/iam/resource_action.py
@@ -20,21 +20,22 @@ from boto3.exceptions import botocore
 
 LOG = logging.getLogger(__name__)
 
-
-def resource_action(client, action='', log_format='item: %(key)s', **kwargs):
+def resource_action(client, action='', log_format='item: %(key)s', raise_errors=False, **kwargs):
     """Call _action_ using boto3 _client_ with _kwargs_.
 
-    This is meant for _action_ methods that will create or implicitely prove a
-    given Resource exists. The _log_failure_ flag is available for methods that
-    should always succeed, but will occasionally fail due to unknown AWS
-    issues.
+    This is meant for _action_ methods that will create or implicitly prove a
+    given Resource exists. This method will fail silently and log errors by default,
+    use the raise_errors flag to change this functionality.  AccessDenied errors will
+    always cause a raised error. EntityAlreadyExists will never raise an error.
 
     Args:
         client (botocore.client.IAM): boto3 client object.
         action (str): Client method to call.
         log_format (str): Generic log message format, 'Added' or 'Found' will
             be prepended depending on the scenario.
-        prefix (str): Prefix word to use in successful INFO message.
+        raise_errors (bool): If errors should be raised, defaults to False.
+            AccessDenied errors will always cause a raised error.
+            EntityAlreadyExists will never raise an error.
         **kwargs: Keyword arguments to pass to _action_ method.
 
     Returns:
@@ -48,7 +49,7 @@ def resource_action(client, action='', log_format='item: %(key)s', **kwargs):
     except botocore.exceptions.ClientError as error:
         error_code = error.response['Error']['Code']
 
-        if error_code == 'AccessDenied':
+        if raise_errors or error_code in "AccessDenied":
             LOG.fatal(error)
             raise
         elif error_code == 'EntityAlreadyExists':

--- a/src/foremast/iam/resource_action.py
+++ b/src/foremast/iam/resource_action.py
@@ -20,6 +20,7 @@ from boto3.exceptions import botocore
 
 LOG = logging.getLogger(__name__)
 
+
 def resource_action(client, action='', log_format='item: %(key)s', raise_errors=False, **kwargs):
     """Call _action_ using boto3 _client_ with _kwargs_.
 


### PR DESCRIPTION
Fixes #400, but marking as draft as I think some discussion is needed.  As noted in the issue, AWS may reject an IAM Policy document which will be logged by Foremast but this will not cause a raised error.  This leads to pipelines looking valid/successful, but upstream the app being deployed will have permissions issues as the IAM policy was rejected.

This comes down to the function `resource_action` failing silently except for `AccessDenied` errors.  This PR updates this to allow disabling silent errors with no change to the default.

I think it would make more sense to never fail silently (or change the default not to fail silently) but I'm not sure what the reason was for the original design or what the implications would be.  Thoughts on that?
