### PR TITLE
feat: Added support for custom tags on ec2 deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 os: linux
 
-dist: xenial
+dist: bionic
 
 jobs:
   include:

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -66,6 +66,25 @@ a specified archaius S3 bucket.
     | *Type*: boolean
     | *Default*: ``false``
 
+``custom_tags``
+***************
+
+Custom Tags to be used during deployment stages on resources such as ELBs and EC2s.
+
+``custom_tags`` *Example*
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+   {
+       "app": {
+            "custom_tags": {
+                "example_key": "example_value",
+                "app_name": "application_name"
+            }
+       }
+   }
+
 .. _eureka_enabled:
 
 ``eureka_enabled``

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -58,6 +58,7 @@ class LambdaFunction:
 
         self.settings = get_properties(prop_path, env=self.env, region=self.region)
         app = self.settings['app']
+        self.custom_tags = app['custom_tags']
         self.lambda_environment = app['lambda_environment']
         self.lambda_layers = app['lambda_layers']
         self.lambda_destinations = app['lambda_destinations']
@@ -258,6 +259,9 @@ class LambdaFunction:
 
         LOG.info('Creating lambda function: %s', self.app_name)
 
+        default_tags = {'app_group': self.group, 'app_name': self.app_name}
+        lambda_tags = {**default_tags, **self.custom_tags}
+
         try:
             self.lambda_client.create_function(
                 Environment=self.lambda_environment,
@@ -271,8 +275,7 @@ class LambdaFunction:
                 MemorySize=int(self.memory),
                 Publish=False,
                 VpcConfig=vpc_config,
-                Tags={'app_group': self.group,
-                      'app_name': self.app_name},
+                Tags=lambda_tags,
                 Layers=self.lambda_layers,
                 DeadLetterConfig=self.lambda_dlq,
                 TracingConfig=self.lambda_tracing,

--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -246,9 +246,12 @@ class S3Apps:
 
     def _put_bucket_tagging(self):
         """Add bucket tags to bucket."""
-        all_tags = self.s3props['tagging']['tags']
-        all_tags.update({'app_group': self.group, 'app_name': self.app_name})
-        tag_set = generate_s3_tags.generated_tag_data(all_tags)
+        app_block_tags = self.properties['app']['custom_tags']
+        s3_block_tags = self.s3props['tagging']['tags']
+        default_tags = {'app_group': self.group, 'app_name': self.app_name}
+
+        s3_tags = {**default_tags, **s3_block_tags, **app_block_tags}
+        tag_set = generate_s3_tags.generated_tag_data(s3_tags)
 
         tagging_config = {'TagSet': tag_set}
 

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -5,6 +5,7 @@
         "approval_timeout": null,
         "archaius_enabled": false,
         "canary": false,
+        "custom_tags": {},
         "email": null,
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",

--- a/src/foremast/templates/pipeline/stage-deploy.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy.json.j2
@@ -35,6 +35,11 @@
           "suspendedProcesses": [],
           "securityGroups": {{ data.app.instance_security_groups }},
           "tags": {
+            {% if data.app.custom_tags %}
+                {% for tag_key, tag_value in data.app.custom_tags.items() -%}
+                  "{{ tag_key }}": "{{ tag_value }}",
+                {% endfor -%}
+            {% endif %}
             "app_group": "{{ data.app.group_name }}",
             "app_name": "{{ data.app.appname }}",
             "owner_email": "{{ data.app.owner_email }}"

--- a/tests/lambda/test_aws.py
+++ b/tests/lambda/test_aws.py
@@ -14,8 +14,9 @@ TEST_PROPERTIES = {
         },
     },
     'app': {
+        'custom_tags': {},
         'lambda_memory': 0,
-        'lambda_timeout': 0,
+        'lambda_timeout': 0,        
         'lambda_environment': None,
         'lambda_layers': None,
         'lambda_dlq': None,


### PR DESCRIPTION
Initial commit getting custom tags to work in deploy stage. Need to continue and add support for other deploy types and custom infra.

- [x] EC2
- [x] ELB
- [x] Lambda
- [x] S3
- [x] etc