### PR TITLE
Support for Specifying Lambda Subnet Purpose

### DIFF
--- a/.github/workflows/githubactions-pypipublish.yml
+++ b/.github/workflows/githubactions-pypipublish.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
+        skip_existing: true
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -240,7 +240,7 @@ The amount of memory to give a Lambda function
     | *Units*: Megabytes
 
 ``lambda_provisioned_throughput``
-***********************
+*********************************
 
 This will allow provisioned throughput of a  lambda function. This specifically will ensure the function is warmed for a provisioned amount to eliminate any function cold starts (not to be confused with VPC cold starts)
 
@@ -270,6 +270,18 @@ More info on limits can be found here: https://docs.aws.amazon.com/lambda/latest
 
     | *Type*: int
     | *Default*: ``<<MAX SUBNET COUNT>>``
+
+``lambda_subnet_purpose``
+*************************
+
+Determines if the instances should be public (external) or non-public (internal).
+
+    | *Type*: string
+    | *Default*: ``"internal"``
+    | *Options*
+
+       - ``"internal"``
+       - ``"external"``
 
 ``lambda_timeout``
 ******************

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -274,7 +274,7 @@ More info on limits can be found here: https://docs.aws.amazon.com/lambda/latest
 ``lambda_subnet_purpose``
 *************************
 
-Determines if the instances should be public (external) or non-public (internal).
+Determines if the AWS Lambda should be public (external) or non-public (internal).
 
     | *Type*: string
     | *Default*: ``"internal"``

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -115,7 +115,8 @@ class LambdaFunction:
     def _vpc_config(self):
         """Get VPC config."""
         if self.vpc_enabled:
-            subnets = get_subnets(env=self.env, region=self.region, purpose=self.subnet_purpose)['subnet_ids'][self.region]
+            subnets_data = get_subnets(env=self.env, region=self.region, purpose=self.subnet_purpose)
+            subnets = subnet_data['subnet_ids'][self.region]
             if self.subnet_count:
                 subnets = subnets[:self.subnet_count]
                 LOG.info('Subnet Count of %s specified. Limiting to subnets: %s', self.subnet_count, subnets)

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -70,6 +70,7 @@ class LambdaFunction:
         self.role = app.get('lambda_role') or generated.iam()['lambda_role']
         self.timeout = app['lambda_timeout']
         self.concurrency_limit = app.get('lambda_concurrency_limit')
+        self.subnet_purpose = app['lambda_subnet_purpose']
         self.subnet_count = app['lambda_subnet_count']
 
         self.role_arn = get_role_arn(self.role, self.env, self.region)
@@ -114,7 +115,7 @@ class LambdaFunction:
     def _vpc_config(self):
         """Get VPC config."""
         if self.vpc_enabled:
-            subnets = get_subnets(env=self.env, region=self.region, purpose='internal')['subnet_ids'][self.region]
+            subnets = get_subnets(env=self.env, region=self.region, purpose=self.subnet_purpose)['subnet_ids'][self.region]
             if self.subnet_count:
                 subnets = subnets[:self.subnet_count]
                 LOG.info('Subnet Count of %s specified. Limiting to subnets: %s', self.subnet_count, subnets)

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -116,7 +116,7 @@ class LambdaFunction:
         """Get VPC config."""
         if self.vpc_enabled:
             subnets_data = get_subnets(env=self.env, region=self.region, purpose=self.subnet_purpose)
-            subnets = subnet_data['subnet_ids'][self.region]
+            subnets = subnets_data['subnet_ids'][self.region]
             if self.subnet_count:
                 subnets = subnets[:self.subnet_count]
                 LOG.info('Subnet Count of %s specified. Limiting to subnets: %s', self.subnet_count, subnets)

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -20,6 +20,7 @@
         "lambda_role": null,
         "lambda_provisioned_throughput": null,
         "lambda_subnet_count": null,
+        "lambda_subnet_purpose": "internal",
         "lambda_timeout": "30",
         "lambda_tracing": {},
         "cloudfunction_timeout": "60",

--- a/tests/lambda/test_aws.py
+++ b/tests/lambda/test_aws.py
@@ -23,6 +23,7 @@ TEST_PROPERTIES = {
         'lambda_tracing': None,
         'lambda_destinations': None,
         'lambda_subnet_count': None,
+        'lambda_subnet_purpose': 'internal',
         'lambda_filesystems': None,
         'lambda_provisioned_throughput': None,
     }


### PR DESCRIPTION
Defaulting to legacy "internal" setting, but overriding to allow teams to set specific subnet purpose su