### PR TITLE
feat: Friendly error when env is not defined in pipeline json files

### DIFF
--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -551,4 +551,3 @@ def debug_flag():
 
     package, *_ = __package__.split('.')
     logging.getLogger(package).setLevel(args.debug)
-


### PR DESCRIPTION
Added a check in Foremast runner to verify the correct env keys are present and if not raise a helpful error:

New: `src.foremast.exceptions.ForemastError: Environment 'env_name' not found in pipeline configs.Check pipeline.json and application-master-env_name.json`

Old: `KeyError: 'env_name'`