### PR TITLE
fix: expontential backoff for lambda resource update conflicts

### DIFF
--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -30,6 +30,7 @@ from ..utils import get_details, get_lambda_arn, get_properties, get_role_arn, g
 
 LOG = logging.getLogger(__name__)
 
+
 class LambdaFunction:
     """Manipulate Lambda function."""
 

--- a/src/foremast/cloudfunction/cloud_functions_client.py
+++ b/src/foremast/cloudfunction/cloud_functions_client.py
@@ -22,6 +22,8 @@ from googleapiclient import discovery
 from ..exceptions import CloudFunctionDeployError, CloudFunctionOperationFailedError, \
     CloudFunctionOperationIncompleteError
 from tryagain import retries
+
+from ..utils import exponential_backoff
 from ..utils.gcp_environment import GcpEnvironment
 
 LOG = logging.getLogger(__name__)
@@ -237,7 +239,7 @@ class CloudFunctionsClient:
             raise e
 
     # Retry with back off, wait time is attempt_count * 2 (1 second, 2 seconds, 4 seconds, etc.)
-    @retries(max_attempts=10, wait=lambda n: 2 ** n, exceptions=CloudFunctionOperationIncompleteError)
+    @retries(max_attempts=10, wait=exponential_backoff, exceptions=CloudFunctionOperationIncompleteError)
     def _wait_for_operation(self, operation_name):
         """Waits for the given operation to complete with an exponential back off.  The back off is
         the number of attempts multiplied by two (in seconds).  Maximum 10 attempts total, for a total of

--- a/src/foremast/utils/__init__.py
+++ b/src/foremast/utils/__init__.py
@@ -40,3 +40,4 @@ from .get_sns_subscriptions import get_sns_subscriptions
 from .get_sns_topic_arn import get_sns_topic_arn
 from .dynamodb_stream import get_dynamodb_stream_arn
 from .roles import *
+from .backoff import *

--- a/src/foremast/utils/backoff.py
+++ b/src/foremast/utils/backoff.py
@@ -1,0 +1,26 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+def exponential_backoff(attempt, exponent=2) -> float:
+    """Exponential backoff function that returns a wait in seconds.  The attempt is multiplied exponentially
+    using the exponent value (default 2).  For example: attempt 2 with an exponent of 4 would be 2^4=16.  This
+    creates a backoff that gets exponentially longer for each attempt mitigating rate limiting and resource
+    conflict errors.
+
+    Use with retries annotation:
+
+    Defaults:
+    @retries(max_attempts=3, wait=exponential_backoff, exceptions=MyError)
+
+    Overriding defaults:
+    @retries(max_attempts=3, wait=lambda n: exponential_backoff(n, 4), exceptions=MyError)
+
+    Args:
+        attempt(int): Int representing the number of attempts so far
+        exponent(float): Exponential modifier used to determine how long to wait
+    """
+    wait = exponent ** attempt
+    LOG.debug("Backing off for {} seconds".format(wait))
+    return wait


### PR DESCRIPTION
With Foremast now uploading code changes for Lambdas we are seeing some occasional `ResourceConflictErrors`, this is a change AWS is rolling out [documented here](https://docs.aws.amazon.com/lambda/latest/dg/functions-states.html).  If a lambda is in a pending update state, any API calls to modify the lambda will fail.  This PR addresses that:

* Added exponential backoff helper for re-use in lambda and cloud function pipelines
* Split lambda create/update methods into smaller functions with individual API calls and backoffs
* Added backoff retry to any lambda class methods making API calls that could cause `ResourceConflictError`

