### PR TITLE
feat: Added app to pipeline_args to pass to Manual Jinja2 templates

### DIFF
--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -50,6 +50,7 @@ class SpinnakerPipeline:
 
         self.base = base
         self.trigger_job = trigger_job
+        self.app = app
         self.generated = get_details(app=app)
         self.app_name = self.generated.app_name()
         self.group_name = self.generated.project
@@ -119,7 +120,9 @@ class SpinnakerPipeline:
         data = {
             'app': {
                 'ami_id': ami_id,
+                'app': self.app,
                 'appname': self.app_name,
+                'app_name': self.app_name,
                 'group_name': self.group_name,
                 'repo_name': self.repo_name,
                 'base': base,

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -72,7 +72,7 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
 
             # Create all pipelines
             for pipeline_dict in pipelines:
-                pipeline_dict.setdefault('application', self.app_name)
+                pipeline_dict.setdefault('application', self.app)
                 pipeline_dict.setdefault('name',
                                          normalize_pipeline_name(name=file_name.lstrip("templates://")))
                 pipeline_dict.setdefault('id', get_pipeline_id(app=pipeline_dict['application'],
@@ -137,6 +137,8 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
         # If any args set in the pipeline file add them to the pipeline_args.variables
         if pipeline_vars is not None:
             pipeline_args["template_variables"] = pipeline_vars
+
+        self.log.debug(pipeline_args)
 
         # Render the template
         return jinja_template.render(pipeline_args)

--- a/src/foremast/pipeline/jinja_functions.py
+++ b/src/foremast/pipeline/jinja_functions.py
@@ -36,6 +36,7 @@ def get_jinja_variables(pipeline):
     # Deprecated variables: Use the app block instead
     variables["trigger_job"] = pipeline.trigger_job
     variables["group_name"] = pipeline.group_name
+    variables["app"] = pipeline.app
     variables["app_name"] = pipeline.app_name
     variables["repo_name"] = pipeline.repo_name
     # Deprecated end
@@ -48,6 +49,8 @@ def get_jinja_variables(pipeline):
     # app block matches non-manual pipeline types like ec2, lambda, etc for consistency
     variables["data"] = {
         'app': {
+            'app': pipeline.app,
+            'app_name': pipeline.app_name,
             'appname': pipeline.app_name,
             'group_name': pipeline.group_name,
             'repo_name': pipeline.repo_name,


### PR DESCRIPTION
Using App allows to render an app_name that is filtered on organization
This is useful if using gitlab.com for example:

- gitlab.com/org/group/repo: repogroup
- gitlab.com/org/repo: repoorg
- github.com/org/repo: repoorg
- git.selfhosted.com/group/sub/repo: reposub
- git.selfhosted.com/group/repo: repogroup